### PR TITLE
Initialize React Native scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Dependencias
+HealthLiveApp/node_modules/
+HealthLiveApp/.gradle/
+HealthLiveApp/android/app/build/
+HealthLiveApp/android/build/
+HealthLiveApp/ios/Pods/
+HealthLiveApp/ios/build/
+
+# Sistema operativo
+.DS_Store
+Thumbs.db
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor
+.vscode/
+.idea/

--- a/HealthLiveApp/.eslintrc.js
+++ b/HealthLiveApp/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  root: true,
+  extends: ['@react-native'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+      rules: {
+        '@typescript-eslint/no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
+      },
+    },
+  ],
+};

--- a/HealthLiveApp/.prettierrc.json
+++ b/HealthLiveApp/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/HealthLiveApp/App.tsx
+++ b/HealthLiveApp/App.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import {SafeAreaView, ScrollView, StatusBar, StyleSheet, View, Text} from 'react-native';
+import MonitoringDashboard from './src/modules/monitoring/components/MonitoringDashboard';
+import ReminderList from './src/modules/reminders/components/ReminderList';
+import ProfileSummary from './src/modules/profile/components/ProfileSummary';
+
+function Section({title, children}: {title: string; children: React.ReactNode}) {
+  return (
+    <View style={styles.sectionContainer}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+function App(): React.JSX.Element {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle="light-content" backgroundColor="#0c4a6e" />
+      <ScrollView contentInsetAdjustmentBehavior="automatic" style={styles.scrollView}>
+        <View style={styles.hero}>
+          <Text style={styles.heroTitle}>Health Live</Text>
+          <Text style={styles.heroSubtitle}>Tu asistente para el bienestar diario</Text>
+        </View>
+        <Section title="Monitoreo en tiempo real">
+          <MonitoringDashboard />
+        </Section>
+        <Section title="Recordatorios personalizados">
+          <ReminderList />
+        </Section>
+        <Section title="Perfil de usuario">
+          <ProfileSummary />
+        </Section>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f8fafc',
+  },
+  scrollView: {
+    paddingHorizontal: 16,
+  },
+  hero: {
+    backgroundColor: '#0284c7',
+    paddingVertical: 24,
+    paddingHorizontal: 16,
+    borderRadius: 16,
+    marginVertical: 16,
+  },
+  heroTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#f8fafc',
+  },
+  heroSubtitle: {
+    fontSize: 16,
+    color: '#e0f2fe',
+    marginTop: 8,
+  },
+  sectionContainer: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#0f172a',
+    shadowOpacity: 0.08,
+    shadowOffset: {width: 0, height: 4},
+    shadowRadius: 12,
+    elevation: 2,
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 12,
+  },
+});
+
+export default App;

--- a/HealthLiveApp/README.md
+++ b/HealthLiveApp/README.md
@@ -1,0 +1,26 @@
+# HealthLiveApp
+
+Plantilla base de la aplicación móvil Health Live desarrollada con React Native.
+
+## Módulos disponibles
+
+- `monitoring`: componentes para visualizar métricas y tendencias de salud.
+- `reminders`: listado de recordatorios y rutinas del usuario.
+- `profile`: resumen del perfil e información contextual del paciente.
+
+Cada módulo expone sus componentes principales mediante un archivo `index.ts` para facilitar su importación desde otras capas.
+
+## Scripts
+
+Ejecutar los scripts desde este directorio:
+
+- `npm run start`
+- `npm run android`
+- `npm run ios`
+- `npm run lint`
+
+## Preparación del entorno
+
+1. Instalar dependencias con `npm install` o `yarn install`.
+2. Instalar pods (solo iOS): `npx pod-install`.
+3. Ejecutar el bundler con `npm run start` y luego correr la app en el simulador o dispositivo deseado.

--- a/HealthLiveApp/android/README.md
+++ b/HealthLiveApp/android/README.md
@@ -1,0 +1,3 @@
+# Proyecto Android
+
+Los archivos nativos generados por `npx react-native init` deben residir aquí. Debido a las restricciones del entorno, solo se incluye una carpeta de marcador de posición.

--- a/HealthLiveApp/app.json
+++ b/HealthLiveApp/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "HealthLiveApp",
+  "displayName": "HealthLiveApp"
+}

--- a/HealthLiveApp/babel.config.js
+++ b/HealthLiveApp/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/HealthLiveApp/index.js
+++ b/HealthLiveApp/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/HealthLiveApp/ios/README.md
+++ b/HealthLiveApp/ios/README.md
@@ -1,0 +1,3 @@
+# Proyecto iOS
+
+Los archivos nativos generados por `npx react-native init` deben residir aquí. Debido a las restricciones del entorno, solo se incluye una carpeta de marcador de posición.

--- a/HealthLiveApp/metro.config.js
+++ b/HealthLiveApp/metro.config.js
@@ -1,0 +1,9 @@
+const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+module.exports = mergeConfig(defaultConfig, {
+  resolver: {
+    sourceExts: [...defaultConfig.resolver.sourceExts, 'cjs'],
+  },
+});

--- a/HealthLiveApp/package.json
+++ b/HealthLiveApp/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "healthliveapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.74.3"
+  },
+  "devDependencies": {
+    "@react-native/eslint-config": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
+    "@tsconfig/react-native": "^3.0.0",
+    "@types/react": "^18.2.45",
+    "@types/react-native": "^0.73.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "prettier": "^3.2.5",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/HealthLiveApp/src/modules/index.ts
+++ b/HealthLiveApp/src/modules/index.ts
@@ -1,0 +1,3 @@
+export * from './monitoring';
+export * from './reminders';
+export * from './profile';

--- a/HealthLiveApp/src/modules/monitoring/components/MonitoringDashboard.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/MonitoringDashboard.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {StyleSheet, View, Text} from 'react-native';
+
+type MetricCardProps = {
+  label: string;
+  value: string;
+  trend?: 'up' | 'down' | 'stable';
+};
+
+const trends: Record<NonNullable<MetricCardProps['trend']>, string> = {
+  up: 'Mejora',
+  down: 'Atención',
+  stable: 'Estable',
+};
+
+const MetricCard: React.FC<MetricCardProps> = ({label, value, trend = 'stable'}) => (
+  <View style={styles.metricCard}>
+    <Text style={styles.metricLabel}>{label}</Text>
+    <Text style={styles.metricValue}>{value}</Text>
+    <Text style={styles.metricTrend}>{trends[trend]}</Text>
+  </View>
+);
+
+const MonitoringDashboard: React.FC = () => (
+  <View style={styles.container}>
+    <MetricCard label="Frecuencia cardiaca" value="72 lpm" trend="up" />
+    <MetricCard label="Calidad del sueño" value="85%" trend="stable" />
+    <MetricCard label="Pasos diarios" value="9.410" trend="down" />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginHorizontal: -6,
+    marginVertical: -6,
+  },
+  metricCard: {
+    flexBasis: '48%',
+    marginHorizontal: 6,
+    marginVertical: 6,
+    backgroundColor: '#e0f2fe',
+    borderRadius: 12,
+    padding: 12,
+  },
+  metricLabel: {
+    fontSize: 14,
+    color: '#0f172a',
+  },
+  metricValue: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginVertical: 8,
+    color: '#0369a1',
+  },
+  metricTrend: {
+    fontSize: 12,
+    color: '#0e7490',
+  },
+});
+
+export default MonitoringDashboard;

--- a/HealthLiveApp/src/modules/monitoring/index.ts
+++ b/HealthLiveApp/src/modules/monitoring/index.ts
@@ -1,0 +1,1 @@
+export {default as MonitoringDashboard} from './components/MonitoringDashboard';

--- a/HealthLiveApp/src/modules/profile/components/ProfileSummary.tsx
+++ b/HealthLiveApp/src/modules/profile/components/ProfileSummary.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {Image, StyleSheet, Text, View} from 'react-native';
+
+const ProfileSummary: React.FC = () => (
+  <View style={styles.container}>
+    <View style={styles.avatarContainer}>
+      <Image
+        source={{uri: 'https://avatars.githubusercontent.com/u/0?v=4'}}
+        style={styles.avatar}
+      />
+    </View>
+    <View style={styles.infoContainer}>
+      <Text style={styles.name}>María Rivera</Text>
+      <Text style={styles.role}>Paciente Premium</Text>
+      <Text style={styles.meta}>Objetivo: mejorar resistencia cardiovascular</Text>
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatarContainer: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    overflow: 'hidden',
+    borderWidth: 2,
+    borderColor: '#38bdf8',
+    marginRight: 16,
+  },
+  avatar: {
+    width: '100%',
+    height: '100%',
+  },
+  infoContainer: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 4,
+  },
+  role: {
+    fontSize: 14,
+    color: '#0369a1',
+    marginBottom: 2,
+  },
+  meta: {
+    fontSize: 12,
+    color: '#1e293b',
+  },
+});
+
+export default ProfileSummary;

--- a/HealthLiveApp/src/modules/profile/index.ts
+++ b/HealthLiveApp/src/modules/profile/index.ts
@@ -1,0 +1,1 @@
+export {default as ProfileSummary} from './components/ProfileSummary';

--- a/HealthLiveApp/src/modules/reminders/components/ReminderList.tsx
+++ b/HealthLiveApp/src/modules/reminders/components/ReminderList.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+
+type Reminder = {
+  id: string;
+  title: string;
+  schedule: string;
+};
+
+const reminders: Reminder[] = [
+  {id: '1', title: 'Tomar medicación matutina', schedule: '07:30 - Todos los días'},
+  {id: '2', title: 'Sesión de estiramientos', schedule: '12:00 - Lunes a Viernes'},
+  {id: '3', title: 'Revisión de hidratación', schedule: 'Cada 2 horas'},
+];
+
+const ReminderList: React.FC = () => (
+  <View>
+    {reminders.map(reminder => (
+      <View key={reminder.id} style={styles.reminderCard}>
+        <Text style={styles.reminderTitle}>{reminder.title}</Text>
+        <Text style={styles.reminderSchedule}>{reminder.schedule}</Text>
+      </View>
+    ))}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  reminderCard: {
+    backgroundColor: '#fef3c7',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+  },
+  reminderTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#92400e',
+  },
+  reminderSchedule: {
+    fontSize: 12,
+    color: '#b45309',
+    marginTop: 4,
+  },
+});
+
+export default ReminderList;

--- a/HealthLiveApp/src/modules/reminders/index.ts
+++ b/HealthLiveApp/src/modules/reminders/index.ts
@@ -1,0 +1,1 @@
+export {default as ReminderList} from './components/ReminderList';

--- a/HealthLiveApp/src/navigation/README.md
+++ b/HealthLiveApp/src/navigation/README.md
@@ -1,0 +1,3 @@
+# Navegación
+
+Este directorio está reservado para los stacks y flujos de navegación que orquestan los módulos de la aplicación.

--- a/HealthLiveApp/src/navigation/index.ts
+++ b/HealthLiveApp/src/navigation/index.ts
@@ -1,0 +1,2 @@
+// Los stacks de navegación se definirán en este directorio.
+export {};

--- a/HealthLiveApp/tsconfig.json
+++ b/HealthLiveApp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/react-native/tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@modules/*": ["src/modules/*"],
+      "@navigation/*": ["src/navigation/*"]
+    }
+  },
+  "include": ["src", "App.tsx", "index.js"],
+  "exclude": ["node_modules"]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# Health_live
-app para monitoreo de salud personal
+# Health Live
+
+Monorepo inicial para la aplicación móvil **Health Live**, enfocada en el monitoreo de la salud personal.
+
+## Framework seleccionado
+
+Se utiliza **React Native** como framework principal. El esqueleto del proyecto fue creado manualmente replicando la estructura generada por `npx react-native init HealthLiveApp`, debido a las restricciones de red del entorno de trabajo. En un entorno con acceso completo bastará ejecutar el comando para regenerar los artefactos nativos.
+
+```bash
+npx react-native init HealthLiveApp
+```
+
+## Estructura del repositorio
+
+```
+Health_live/
+├── .gitignore
+├── README.md
+└── HealthLiveApp/
+    ├── App.tsx
+    ├── app.json
+    ├── babel.config.js
+    ├── index.js
+    ├── metro.config.js
+    ├── package.json
+    ├── tsconfig.json
+    ├── android/
+    ├── ios/
+    └── src/
+        ├── modules/
+        │   ├── monitoring/
+        │   ├── reminders/
+        │   └── profile/
+        └── navigation/
+```
+
+Cada módulo cuenta con sus propios componentes y puntos de entrada (`index.ts`) para facilitar la reutilización y el escalado.
+
+## Dependencias principales
+
+Las dependencias y herramientas incluidas en `HealthLiveApp/package.json` son:
+
+- **react-native 0.74.3** y **react 18.2.0** para el desarrollo multiplataforma.
+- **TypeScript 5** para tipado estático en los módulos.
+- **ESLint**, **Prettier** y `@react-native/eslint-config` para mantener un estilo de código consistente.
+- Tipados específicos para React y React Native (`@types/react`, `@types/react-native`).
+
+> Nota: no se ejecutó `npm install` en este entorno por falta de acceso al registro de npm. Antes de iniciar el desarrollo en una máquina local será necesario instalar las dependencias con `npm install` o `yarn install`.
+
+## Scripts de desarrollo
+
+Desde el directorio `HealthLiveApp` se encuentran disponibles los siguientes scripts:
+
+- `npm run start`: inicia el bundler de Metro.
+- `npm run android`: compila y lanza la aplicación en un emulador o dispositivo Android.
+- `npm run ios`: compila y lanza la aplicación en un simulador iOS.
+- `npm run lint`: ejecuta ESLint sobre el proyecto.
+
+## Próximos pasos sugeridos
+
+1. Ejecutar `npm install` dentro de `HealthLiveApp`.
+2. Generar los proyectos nativos completos con `npx react-native init HealthLiveApp` o sincronizar los artefactos mediante `npx react-native upgrade`.
+3. Configurar integraciones con dispositivos o servicios de salud para alimentar el módulo de monitoreo.
+4. Definir casos de uso para los recordatorios y personalización del perfil del usuario.


### PR DESCRIPTION
## Summary
- scaffold a React Native project under `HealthLiveApp` with TypeScript configuration
- add dedicated module directories for monitoring, reminders, and profile features
- document dependencies, scripts, and repository structure in the root README and project README

## Testing
- Not run (network restrictions prevented installing npm dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68cf6b538bf0833194ac4dfe4d4bfd39