### PR TITLE
Implement health metric forms with local persistence

### DIFF
--- a/HealthLiveApp/package.json
+++ b/HealthLiveApp/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "18.2.0",
-    "react-native": "0.74.3"
+    "react-native": "0.74.3",
+    "@react-native-async-storage/async-storage": "^1.21.0"
   },
   "devDependencies": {
     "@react-native/eslint-config": "^0.74.0",

--- a/HealthLiveApp/src/modules/monitoring/components/MonitoringDashboard.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/MonitoringDashboard.tsx
@@ -1,63 +1,21 @@
 import React from 'react';
-import {StyleSheet, View, Text} from 'react-native';
-
-type MetricCardProps = {
-  label: string;
-  value: string;
-  trend?: 'up' | 'down' | 'stable';
-};
-
-const trends: Record<NonNullable<MetricCardProps['trend']>, string> = {
-  up: 'Mejora',
-  down: 'Atención',
-  stable: 'Estable',
-};
-
-const MetricCard: React.FC<MetricCardProps> = ({label, value, trend = 'stable'}) => (
-  <View style={styles.metricCard}>
-    <Text style={styles.metricLabel}>{label}</Text>
-    <Text style={styles.metricValue}>{value}</Text>
-    <Text style={styles.metricTrend}>{trends[trend]}</Text>
-  </View>
-);
+import {StyleSheet, View} from 'react-native';
+import BodyCompositionSection from './sections/BodyCompositionSection';
+import BloodPressureSection from './sections/BloodPressureSection';
+import GlucoseSection from './sections/GlucoseSection';
+import LipidSection from './sections/LipidSection';
 
 const MonitoringDashboard: React.FC = () => (
   <View style={styles.container}>
-    <MetricCard label="Frecuencia cardiaca" value="72 lpm" trend="up" />
-    <MetricCard label="Calidad del sueño" value="85%" trend="stable" />
-    <MetricCard label="Pasos diarios" value="9.410" trend="down" />
+    <BloodPressureSection />
+    <GlucoseSection />
+    <LipidSection />
+    <BodyCompositionSection />
   </View>
 );
 
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    marginHorizontal: -6,
-    marginVertical: -6,
-  },
-  metricCard: {
-    flexBasis: '48%',
-    marginHorizontal: 6,
-    marginVertical: 6,
-    backgroundColor: '#e0f2fe',
-    borderRadius: 12,
-    padding: 12,
-  },
-  metricLabel: {
-    fontSize: 14,
-    color: '#0f172a',
-  },
-  metricValue: {
-    fontSize: 24,
-    fontWeight: '700',
-    marginVertical: 8,
-    color: '#0369a1',
-  },
-  metricTrend: {
-    fontSize: 12,
-    color: '#0e7490',
-  },
+  container: {},
 });
 
 export default MonitoringDashboard;

--- a/HealthLiveApp/src/modules/monitoring/components/forms/BloodPressureForm.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/forms/BloodPressureForm.tsx
@@ -1,0 +1,145 @@
+import React, {useMemo, useState} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import type {BloodPressureRecord} from '../../domain';
+import FormField from './FormField';
+
+type BloodPressureFormProps = {
+  onSubmit: (record: Omit<BloodPressureRecord, 'id'>) => Promise<void> | void;
+};
+
+type Errors = Partial<Record<'systolic' | 'diastolic' | 'recordedAt', string>>;
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const BloodPressureForm: React.FC<BloodPressureFormProps> = ({onSubmit}) => {
+  const [systolic, setSystolic] = useState('');
+  const [diastolic, setDiastolic] = useState('');
+  const [pulse, setPulse] = useState('');
+  const [recordedAt, setRecordedAt] = useState(today());
+  const [errors, setErrors] = useState<Errors>({});
+
+  const isValidDate = useMemo(
+    () => (value: string) => {
+      if (!value) {
+        return false;
+      }
+      const parsed = Date.parse(value);
+      if (Number.isNaN(parsed)) {
+        return false;
+      }
+      return parsed <= Date.now();
+    },
+    [],
+  );
+
+  const handleSubmit = () => {
+    const nextErrors: Errors = {};
+    const systolicValue = Number(systolic);
+    const diastolicValue = Number(diastolic);
+
+    if (!systolic || Number.isNaN(systolicValue) || systolicValue <= 0) {
+      nextErrors.systolic = 'Ingresa una cifra válida para la presión sistólica.';
+    }
+    if (!diastolic || Number.isNaN(diastolicValue) || diastolicValue <= 0) {
+      nextErrors.diastolic = 'Ingresa una cifra válida para la presión diastólica.';
+    }
+    if (!isValidDate(recordedAt)) {
+      nextErrors.recordedAt = 'La fecha debe tener el formato AAAA-MM-DD y no ser futura.';
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    const pulseValue = pulse ? Number(pulse) : undefined;
+
+    onSubmit({
+      systolic: systolicValue,
+      diastolic: diastolicValue,
+      pulse: pulseValue,
+      recordedAt: new Date(recordedAt).toISOString(),
+    });
+    setErrors({});
+    setSystolic('');
+    setDiastolic('');
+    setPulse('');
+    setRecordedAt(today());
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.formTitle}>Nuevo registro</Text>
+      <View style={styles.row}>
+        <View style={[styles.fieldWrapper, styles.fieldSpacing]}>
+          <FormField
+            label="Sistólica (mmHg)"
+            keyboardType="numeric"
+            value={systolic}
+            onChangeText={setSystolic}
+            error={errors.systolic}
+            accessibilityLabel="Valor sistólico"
+          />
+        </View>
+        <View style={styles.fieldWrapper}>
+          <FormField
+            label="Diastólica (mmHg)"
+            keyboardType="numeric"
+            value={diastolic}
+            onChangeText={setDiastolic}
+            error={errors.diastolic}
+            accessibilityLabel="Valor diastólico"
+          />
+        </View>
+      </View>
+      <FormField
+        label="Frecuencia cardiaca (opcional)"
+        keyboardType="numeric"
+        value={pulse}
+        onChangeText={setPulse}
+        accessibilityLabel="Frecuencia cardiaca"
+      />
+      <FormField
+        label="Fecha"
+        placeholder="AAAA-MM-DD"
+        value={recordedAt}
+        onChangeText={setRecordedAt}
+        error={errors.recordedAt}
+        accessibilityLabel="Fecha del registro"
+      />
+      <Text style={styles.submit} onPress={handleSubmit} accessibilityRole="button">
+        Guardar registro
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#eff6ff',
+    borderRadius: 16,
+    padding: 16,
+  },
+  formTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  fieldWrapper: {
+    flex: 1,
+  },
+  fieldSpacing: {
+    marginRight: 12,
+  },
+  submit: {
+    marginTop: 8,
+    color: '#1d4ed8',
+    fontWeight: '600',
+  },
+});
+
+export default BloodPressureForm;

--- a/HealthLiveApp/src/modules/monitoring/components/forms/BodyCompositionForm.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/forms/BodyCompositionForm.tsx
@@ -1,0 +1,126 @@
+import React, {useState} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import type {BodyCompositionRecord} from '../../domain';
+import FormField from './FormField';
+
+type BodyCompositionFormProps = {
+  onSubmit: (record: Omit<BodyCompositionRecord, 'id'>) => Promise<void> | void;
+};
+
+type Errors = Partial<Record<'weightKg' | 'heightCm' | 'recordedAt', string>>;
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const BodyCompositionForm: React.FC<BodyCompositionFormProps> = ({onSubmit}) => {
+  const [weight, setWeight] = useState('');
+  const [height, setHeight] = useState('');
+  const [recordedAt, setRecordedAt] = useState(today());
+  const [errors, setErrors] = useState<Errors>({});
+
+  const handleSubmit = () => {
+    const nextErrors: Errors = {};
+    const weightValue = Number(weight);
+    const heightValue = Number(height);
+
+    if (!weight || Number.isNaN(weightValue) || weightValue <= 0) {
+      nextErrors.weightKg = 'Introduce un peso válido en kilogramos.';
+    }
+    if (!height || Number.isNaN(heightValue) || heightValue <= 0) {
+      nextErrors.heightCm = 'Introduce una estatura válida en centímetros.';
+    }
+
+    const parsedDate = Date.parse(recordedAt);
+    if (!recordedAt || Number.isNaN(parsedDate) || parsedDate > Date.now()) {
+      nextErrors.recordedAt = 'La fecha debe tener el formato AAAA-MM-DD y no ser futura.';
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    const heightMeters = heightValue / 100;
+    const bmi = Number((weightValue / (heightMeters * heightMeters)).toFixed(2));
+
+    onSubmit({
+      weightKg: weightValue,
+      heightCm: heightValue,
+      bmi,
+      recordedAt: new Date(recordedAt).toISOString(),
+    });
+
+    setErrors({});
+    setWeight('');
+    setHeight('');
+    setRecordedAt(today());
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.formTitle}>Nuevo registro</Text>
+      <View style={styles.row}>
+        <View style={[styles.fieldWrapper, styles.fieldSpacing]}>
+          <FormField
+            label="Peso (kg)"
+            keyboardType="numeric"
+            value={weight}
+            onChangeText={setWeight}
+            error={errors.weightKg}
+            accessibilityLabel="Peso en kilogramos"
+          />
+        </View>
+        <View style={styles.fieldWrapper}>
+          <FormField
+            label="Estatura (cm)"
+            keyboardType="numeric"
+            value={height}
+            onChangeText={setHeight}
+            error={errors.heightCm}
+            accessibilityLabel="Estatura en centímetros"
+          />
+        </View>
+      </View>
+      <FormField
+        label="Fecha"
+        placeholder="AAAA-MM-DD"
+        value={recordedAt}
+        onChangeText={setRecordedAt}
+        error={errors.recordedAt}
+        accessibilityLabel="Fecha del registro de peso"
+      />
+      <Text style={styles.submit} onPress={handleSubmit} accessibilityRole="button">
+        Guardar registro
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#dcfce7',
+    borderRadius: 16,
+    padding: 16,
+  },
+  formTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  fieldWrapper: {
+    flex: 1,
+  },
+  fieldSpacing: {
+    marginRight: 12,
+  },
+  submit: {
+    marginTop: 8,
+    color: '#15803d',
+    fontWeight: '600',
+  },
+});
+
+export default BodyCompositionForm;

--- a/HealthLiveApp/src/modules/monitoring/components/forms/FormField.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/forms/FormField.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {StyleSheet, Text, TextInput, View, TextInputProps} from 'react-native';
+
+type FormFieldProps = TextInputProps & {
+  label: string;
+  error?: string;
+};
+
+const FormField: React.FC<FormFieldProps> = ({label, error, style, ...props}) => (
+  <View style={styles.container}>
+    <Text style={styles.label}>{label}</Text>
+    <TextInput
+      style={[styles.input, style, error ? styles.inputError : null]}
+      placeholderTextColor="#94a3b8"
+      {...props}
+    />
+    {error ? <Text style={styles.errorText}>{error}</Text> : null}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 12,
+  },
+  label: {
+    fontSize: 13,
+    color: '#0f172a',
+    marginBottom: 4,
+    fontWeight: '500',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 15,
+    color: '#0f172a',
+    backgroundColor: '#f8fafc',
+  },
+  inputError: {
+    borderColor: '#ef4444',
+  },
+  errorText: {
+    color: '#dc2626',
+    fontSize: 12,
+    marginTop: 4,
+  },
+});
+
+export default FormField;

--- a/HealthLiveApp/src/modules/monitoring/components/forms/GlucoseForm.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/forms/GlucoseForm.tsx
@@ -1,0 +1,135 @@
+import React, {useState} from 'react';
+import {Pressable, StyleSheet, Text, View} from 'react-native';
+import type {GlucoseContext, GlucoseRecord} from '../../domain';
+import FormField from './FormField';
+
+type GlucoseFormProps = {
+  onSubmit: (record: Omit<GlucoseRecord, 'id'>) => Promise<void> | void;
+};
+
+type Errors = Partial<Record<'value' | 'recordedAt', string>>;
+
+const contexts: GlucoseContext[] = ['ayunas', 'postprandial', 'aleatoria'];
+const today = () => new Date().toISOString().slice(0, 10);
+
+const GlucoseForm: React.FC<GlucoseFormProps> = ({onSubmit}) => {
+  const [value, setValue] = useState('');
+  const [context, setContext] = useState<GlucoseContext>('ayunas');
+  const [recordedAt, setRecordedAt] = useState(today());
+  const [errors, setErrors] = useState<Errors>({});
+
+  const handleSubmit = () => {
+    const nextErrors: Errors = {};
+    const parsedValue = Number(value);
+
+    if (!value || Number.isNaN(parsedValue) || parsedValue <= 0) {
+      nextErrors.value = 'Introduce un valor de glucosa válido.';
+    }
+
+    const parsedDate = Date.parse(recordedAt);
+    if (!recordedAt || Number.isNaN(parsedDate) || parsedDate > Date.now()) {
+      nextErrors.recordedAt = 'La fecha debe tener el formato AAAA-MM-DD y no ser futura.';
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    onSubmit({
+      value: parsedValue,
+      context,
+      recordedAt: new Date(recordedAt).toISOString(),
+    });
+
+    setErrors({});
+    setValue('');
+    setRecordedAt(today());
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.formTitle}>Nuevo registro</Text>
+      <FormField
+        label="Glucosa (mg/dL)"
+        keyboardType="numeric"
+        value={value}
+        onChangeText={setValue}
+        error={errors.value}
+        accessibilityLabel="Valor de glucosa"
+      />
+      <View style={styles.contextRow}>
+        {contexts.map(item => (
+          <Pressable
+            key={item}
+            style={[styles.contextChip, item === context && styles.contextChipActive]}
+            onPress={() => setContext(item)}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.contextText, item === context && styles.contextTextActive]}>
+              {item.charAt(0).toUpperCase() + item.slice(1)}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+      <FormField
+        label="Fecha"
+        placeholder="AAAA-MM-DD"
+        value={recordedAt}
+        onChangeText={setRecordedAt}
+        error={errors.recordedAt}
+        accessibilityLabel="Fecha del registro de glucosa"
+      />
+      <Text style={styles.submit} onPress={handleSubmit} accessibilityRole="button">
+        Guardar registro
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fef9c3',
+    borderRadius: 16,
+    padding: 16,
+  },
+  formTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 12,
+  },
+  contextRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  contextChip: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#fde68a',
+    backgroundColor: '#fff7ed',
+  },
+  contextChipActive: {
+    backgroundColor: '#facc15',
+    borderColor: '#eab308',
+  },
+  contextText: {
+    fontSize: 13,
+    color: '#92400e',
+    textTransform: 'capitalize',
+  },
+  contextTextActive: {
+    color: '#78350f',
+    fontWeight: '600',
+  },
+  submit: {
+    marginTop: 8,
+    color: '#ca8a04',
+    fontWeight: '600',
+  },
+});
+
+export default GlucoseForm;

--- a/HealthLiveApp/src/modules/monitoring/components/forms/LipidForm.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/forms/LipidForm.tsx
@@ -1,0 +1,161 @@
+import React, {useState} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import type {LipidRecord} from '../../domain';
+import FormField from './FormField';
+
+type LipidFormProps = {
+  onSubmit: (record: Omit<LipidRecord, 'id'>) => Promise<void> | void;
+};
+
+type Errors = Partial<
+  Record<'totalCholesterol' | 'hdl' | 'ldl' | 'triglycerides' | 'recordedAt', string>
+>;
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const LipidForm: React.FC<LipidFormProps> = ({onSubmit}) => {
+  const [totalCholesterol, setTotalCholesterol] = useState('');
+  const [hdl, setHdl] = useState('');
+  const [ldl, setLdl] = useState('');
+  const [triglycerides, setTriglycerides] = useState('');
+  const [recordedAt, setRecordedAt] = useState(today());
+  const [errors, setErrors] = useState<Errors>({});
+
+  const handleSubmit = () => {
+    const nextErrors: Errors = {};
+
+    const total = Number(totalCholesterol);
+    const hdlValue = Number(hdl);
+    const ldlValue = Number(ldl);
+    const trigValue = Number(triglycerides);
+
+    if (!total || Number.isNaN(total) || total <= 0) {
+      nextErrors.totalCholesterol = 'Introduce un valor válido de colesterol total.';
+    }
+    if (!hdl || Number.isNaN(hdlValue) || hdlValue <= 0) {
+      nextErrors.hdl = 'Introduce un valor válido de HDL.';
+    }
+    if (!ldl || Number.isNaN(ldlValue) || ldlValue <= 0) {
+      nextErrors.ldl = 'Introduce un valor válido de LDL.';
+    }
+    if (!triglycerides || Number.isNaN(trigValue) || trigValue <= 0) {
+      nextErrors.triglycerides = 'Introduce un valor válido de triglicéridos.';
+    }
+
+    const parsedDate = Date.parse(recordedAt);
+    if (!recordedAt || Number.isNaN(parsedDate) || parsedDate > Date.now()) {
+      nextErrors.recordedAt = 'La fecha debe tener el formato AAAA-MM-DD y no ser futura.';
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    onSubmit({
+      totalCholesterol: total,
+      hdl: hdlValue,
+      ldl: ldlValue,
+      triglycerides: trigValue,
+      recordedAt: new Date(recordedAt).toISOString(),
+    });
+
+    setErrors({});
+    setTotalCholesterol('');
+    setHdl('');
+    setLdl('');
+    setTriglycerides('');
+    setRecordedAt(today());
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.formTitle}>Nuevo registro</Text>
+      <View style={styles.row}>
+        <View style={[styles.fieldWrapper, styles.fieldSpacing]}>
+          <FormField
+            label="Total"
+            keyboardType="numeric"
+            value={totalCholesterol}
+            onChangeText={setTotalCholesterol}
+            error={errors.totalCholesterol}
+            accessibilityLabel="Colesterol total"
+          />
+        </View>
+        <View style={styles.fieldWrapper}>
+          <FormField
+            label="HDL"
+            keyboardType="numeric"
+            value={hdl}
+            onChangeText={setHdl}
+            error={errors.hdl}
+            accessibilityLabel="HDL"
+          />
+        </View>
+      </View>
+      <View style={styles.row}>
+        <View style={[styles.fieldWrapper, styles.fieldSpacing]}>
+          <FormField
+            label="LDL"
+            keyboardType="numeric"
+            value={ldl}
+            onChangeText={setLdl}
+            error={errors.ldl}
+            accessibilityLabel="LDL"
+          />
+        </View>
+        <View style={styles.fieldWrapper}>
+          <FormField
+            label="Triglicéridos"
+            keyboardType="numeric"
+            value={triglycerides}
+            onChangeText={setTriglycerides}
+            error={errors.triglycerides}
+            accessibilityLabel="Triglicéridos"
+          />
+        </View>
+      </View>
+      <FormField
+        label="Fecha"
+        placeholder="AAAA-MM-DD"
+        value={recordedAt}
+        onChangeText={setRecordedAt}
+        error={errors.recordedAt}
+        accessibilityLabel="Fecha del perfil lipídico"
+      />
+      <Text style={styles.submit} onPress={handleSubmit} accessibilityRole="button">
+        Guardar registro
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#ede9fe',
+    borderRadius: 16,
+    padding: 16,
+  },
+  formTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  fieldWrapper: {
+    flex: 1,
+  },
+  fieldSpacing: {
+    marginRight: 12,
+  },
+  submit: {
+    marginTop: 8,
+    color: '#6d28d9',
+    fontWeight: '600',
+  },
+});
+
+export default LipidForm;

--- a/HealthLiveApp/src/modules/monitoring/components/history/AlertBanner.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/history/AlertBanner.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+
+type AlertBannerProps = {
+  message: string;
+};
+
+const AlertBanner: React.FC<AlertBannerProps> = ({message}) => (
+  <View style={styles.container}>
+    <Text style={styles.text}>⚠️ {message}</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fef3c7',
+    borderColor: '#f59e0b',
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 8,
+  },
+  text: {
+    color: '#92400e',
+    fontSize: 13,
+  },
+});
+
+export default AlertBanner;

--- a/HealthLiveApp/src/modules/monitoring/components/history/MetricHistory.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/history/MetricHistory.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import type {MetricAlert, MetricRecordBase} from '../../domain';
+import AlertBanner from './AlertBanner';
+
+type ChartSeries = {
+  label: string;
+  data: number[];
+  color: string;
+  threshold?: number;
+};
+
+type MetricHistoryProps<T extends MetricRecordBase> = {
+  records: T[];
+  series: ChartSeries[];
+  categories: string[];
+  alerts: MetricAlert[];
+  renderRecord: (record: T) => React.ReactNode;
+};
+
+const MetricHistory = <T extends MetricRecordBase>({
+  records,
+  series,
+  categories,
+  alerts,
+  renderRecord,
+}: MetricHistoryProps<T>) => {
+  const hasData = records.length > 0;
+  const maxValue = Math.max(
+    ...series.map(current => Math.max(...current.data, 0)),
+    0,
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Historial reciente</Text>
+      {alerts.map(alert => (
+        <AlertBanner key={`${alert.recordId}-${alert.message}`} message={alert.message} />
+      ))}
+      {hasData ? (
+        <>
+          <View style={styles.chartContainer}>
+            {categories.map((category, index) => (
+              <View style={styles.chartColumn} key={category}>
+                <View style={styles.barGroup}>
+                  {series.map(serie => {
+                    const value = serie.data[index] ?? 0;
+                    const heightRatio = maxValue === 0 ? 0 : value / maxValue;
+                    const barHeight = Math.max(8, Math.round(heightRatio * 100));
+                    const exceedsThreshold =
+                      typeof serie.threshold === 'number' && value >= serie.threshold;
+                    return (
+                      <View
+                        key={`${serie.label}-${category}`}
+                        style={[
+                          styles.bar,
+                          {
+                            height: barHeight,
+                            backgroundColor: exceedsThreshold ? '#dc2626' : serie.color,
+                          },
+                        ]}
+                      />
+                    );
+                  })}
+                </View>
+                <Text style={styles.category}>{category}</Text>
+              </View>
+            ))}
+          </View>
+          <View>
+            {records.slice(-3).reverse().map(record => (
+              <View style={styles.recordRow} key={record.id}>
+                {renderRecord(record)}
+              </View>
+            ))}
+          </View>
+        </>
+      ) : (
+        <Text style={styles.empty}>Aún no has registrado datos para esta métrica.</Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 16,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 12,
+  },
+  chartContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 12,
+    padding: 12,
+    minHeight: 140,
+  },
+  chartColumn: {
+    alignItems: 'center',
+    flex: 1,
+    marginHorizontal: 4,
+  },
+  barGroup: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    flex: 1,
+  },
+  bar: {
+    width: 12,
+    borderRadius: 6,
+    backgroundColor: '#0284c7',
+    marginHorizontal: 2,
+  },
+  category: {
+    fontSize: 11,
+    color: '#475569',
+    marginTop: 6,
+  },
+  recordRow: {
+    borderBottomWidth: 1,
+    borderBottomColor: '#e2e8f0',
+    paddingVertical: 8,
+  },
+  empty: {
+    color: '#475569',
+    fontSize: 13,
+  },
+});
+
+export default MetricHistory;

--- a/HealthLiveApp/src/modules/monitoring/components/sections/BloodPressureSection.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/sections/BloodPressureSection.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import {
+  BloodPressureRecord,
+  DEFAULT_THRESHOLDS,
+  buildAlerts,
+} from '../../domain';
+import {useMetricRecords} from '../../hooks';
+import {formatShortDate} from '../../utils/date';
+import BloodPressureForm from '../forms/BloodPressureForm';
+import MetricHistory from '../history/MetricHistory';
+import MetricSection from './MetricSection';
+
+const BloodPressureSection: React.FC = () => {
+  const {records, addRecord} = useMetricRecords('bloodPressure');
+  const categories = records.map(item => formatShortDate(item.recordedAt));
+  const alerts = buildAlerts('bloodPressure', records);
+
+  return (
+    <MetricSection
+      title="Presión arterial"
+      description="Registra tus mediciones manuales para identificar tendencias y compartirlas con tu equipo médico."
+    >
+      <BloodPressureForm onSubmit={addRecord} />
+      <MetricHistory<BloodPressureRecord>
+        records={records}
+        series={[
+          {
+            label: 'Sistólica',
+            data: records.map(item => item.systolic),
+            color: '#ef4444',
+            threshold: DEFAULT_THRESHOLDS.bloodPressure.systolic,
+          },
+          {
+            label: 'Diastólica',
+            data: records.map(item => item.diastolic),
+            color: '#fb923c',
+            threshold: DEFAULT_THRESHOLDS.bloodPressure.diastolic,
+          },
+        ]}
+        categories={categories}
+        alerts={alerts}
+        renderRecord={(record: BloodPressureRecord) => (
+          <View style={styles.historyRow}>
+            <Text style={styles.historyDate}>{formatShortDate(record.recordedAt)}</Text>
+            <Text style={styles.historyValue}>
+              {record.systolic}/{record.diastolic} mmHg
+            </Text>
+            {record.pulse ? (
+              <Text style={styles.historyTag}>{record.pulse} lpm</Text>
+            ) : null}
+          </View>
+        )}
+      />
+    </MetricSection>
+  );
+};
+
+const styles = StyleSheet.create({
+  historyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  historyDate: {
+    color: '#475569',
+    fontSize: 13,
+    flexBasis: 72,
+    marginRight: 8,
+  },
+  historyValue: {
+    color: '#0f172a',
+    fontSize: 15,
+    fontWeight: '600',
+    flex: 1,
+    marginRight: 8,
+  },
+  historyTag: {
+    color: '#0ea5e9',
+    fontSize: 13,
+  },
+});
+
+export default BloodPressureSection;

--- a/HealthLiveApp/src/modules/monitoring/components/sections/BodyCompositionSection.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/sections/BodyCompositionSection.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import {BodyCompositionRecord, DEFAULT_THRESHOLDS, buildAlerts} from '../../domain';
+import {useMetricRecords} from '../../hooks';
+import {formatShortDate} from '../../utils/date';
+import BodyCompositionForm from '../forms/BodyCompositionForm';
+import MetricHistory from '../history/MetricHistory';
+import MetricSection from './MetricSection';
+
+const BodyCompositionSection: React.FC = () => {
+  const {records, addRecord} = useMetricRecords('bodyComposition');
+  const categories = records.map(item => formatShortDate(item.recordedAt));
+  const alerts = buildAlerts('bodyComposition', records);
+
+  return (
+    <MetricSection
+      title="Peso e IMC"
+      description="Controla tu evolución antropométrica y evalúa el impacto de los cambios de estilo de vida."
+    >
+      <BodyCompositionForm onSubmit={addRecord} />
+      <MetricHistory<BodyCompositionRecord>
+        records={records}
+        series={[
+          {
+            label: 'Peso',
+            data: records.map(item => item.weightKg),
+            color: '#10b981',
+          },
+          {
+            label: 'IMC',
+            data: records.map(item => item.bmi),
+            color: '#059669',
+            threshold: DEFAULT_THRESHOLDS.bodyComposition.bmiHigh,
+          },
+        ]}
+        categories={categories}
+        alerts={alerts}
+        renderRecord={(record: BodyCompositionRecord) => (
+          <View style={styles.historyRow}>
+            <Text style={styles.historyDate}>{formatShortDate(record.recordedAt)}</Text>
+            <Text style={styles.historyValue}>{record.weightKg} kg</Text>
+            <Text style={styles.historyTag}>IMC {record.bmi}</Text>
+          </View>
+        )}
+      />
+    </MetricSection>
+  );
+};
+
+const styles = StyleSheet.create({
+  historyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  historyDate: {
+    color: '#475569',
+    fontSize: 13,
+    flexBasis: 72,
+    marginRight: 8,
+  },
+  historyValue: {
+    color: '#0f172a',
+    fontSize: 15,
+    fontWeight: '600',
+    flex: 1,
+    marginRight: 8,
+  },
+  historyTag: {
+    color: '#047857',
+    fontSize: 13,
+  },
+});
+
+export default BodyCompositionSection;

--- a/HealthLiveApp/src/modules/monitoring/components/sections/GlucoseSection.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/sections/GlucoseSection.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import {DEFAULT_THRESHOLDS, GlucoseRecord, buildAlerts} from '../../domain';
+import {useMetricRecords} from '../../hooks';
+import {formatShortDate} from '../../utils/date';
+import GlucoseForm from '../forms/GlucoseForm';
+import MetricHistory from '../history/MetricHistory';
+import MetricSection from './MetricSection';
+
+const GlucoseSection: React.FC = () => {
+  const {records, addRecord} = useMetricRecords('glucose');
+  const categories = records.map(item => formatShortDate(item.recordedAt));
+  const alerts = buildAlerts('glucose', records);
+
+  return (
+    <MetricSection
+      title="Glucosa"
+      description="Monitorea tus mediciones capilares y contextualízalas según el momento del día."
+    >
+      <GlucoseForm onSubmit={addRecord} />
+      <MetricHistory<GlucoseRecord>
+        records={records}
+        series={[
+          {
+            label: 'Glucosa',
+            data: records.map(item => item.value),
+            color: '#f97316',
+            threshold: DEFAULT_THRESHOLDS.glucose.value,
+          },
+        ]}
+        categories={categories}
+        alerts={alerts}
+        renderRecord={(record: GlucoseRecord) => (
+          <View style={styles.historyRow}>
+            <Text style={styles.historyDate}>{formatShortDate(record.recordedAt)}</Text>
+            <Text style={styles.historyValue}>{record.value} mg/dL</Text>
+            <Text style={styles.historyTag}>{record.context}</Text>
+          </View>
+        )}
+      />
+    </MetricSection>
+  );
+};
+
+const styles = StyleSheet.create({
+  historyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  historyDate: {
+    color: '#475569',
+    fontSize: 13,
+    flexBasis: 72,
+    marginRight: 8,
+  },
+  historyValue: {
+    color: '#0f172a',
+    fontSize: 15,
+    fontWeight: '600',
+    flex: 1,
+    marginRight: 8,
+  },
+  historyTag: {
+    color: '#9a3412',
+    fontSize: 13,
+    textTransform: 'capitalize',
+  },
+});
+
+export default GlucoseSection;

--- a/HealthLiveApp/src/modules/monitoring/components/sections/LipidSection.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/sections/LipidSection.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import {DEFAULT_THRESHOLDS, LipidRecord, buildAlerts} from '../../domain';
+import {useMetricRecords} from '../../hooks';
+import {formatShortDate} from '../../utils/date';
+import LipidForm from '../forms/LipidForm';
+import MetricHistory from '../history/MetricHistory';
+import MetricSection from './MetricSection';
+
+const LipidSection: React.FC = () => {
+  const {records, addRecord} = useMetricRecords('lipids');
+  const categories = records.map(item => formatShortDate(item.recordedAt));
+  const alerts = buildAlerts('lipids', records);
+
+  return (
+    <MetricSection
+      title="Perfil lipídico"
+      description="Da seguimiento a tus resultados de laboratorio para medir el impacto del tratamiento."
+    >
+      <LipidForm onSubmit={addRecord} />
+      <MetricHistory<LipidRecord>
+        records={records}
+        series={[
+          {
+            label: 'Total',
+            data: records.map(item => item.totalCholesterol),
+            color: '#a855f7',
+            threshold: DEFAULT_THRESHOLDS.lipids.totalCholesterol,
+          },
+          {
+            label: 'LDL',
+            data: records.map(item => item.ldl),
+            color: '#7c3aed',
+            threshold: DEFAULT_THRESHOLDS.lipids.ldl,
+          },
+          {
+            label: 'Triglicéridos',
+            data: records.map(item => item.triglycerides),
+            color: '#c026d3',
+            threshold: DEFAULT_THRESHOLDS.lipids.triglycerides,
+          },
+        ]}
+        categories={categories}
+        alerts={alerts}
+        renderRecord={(record: LipidRecord) => (
+          <View style={styles.historyRow}>
+            <Text style={styles.historyDate}>{formatShortDate(record.recordedAt)}</Text>
+            <View style={styles.historyValues}>
+              <Text style={styles.historyValue}>Total: {record.totalCholesterol}</Text>
+              <Text style={styles.historyValue}>LDL: {record.ldl}</Text>
+              <Text style={styles.historyValue}>HDL: {record.hdl}</Text>
+              <Text style={styles.historyValue}>TG: {record.triglycerides}</Text>
+            </View>
+          </View>
+        )}
+      />
+    </MetricSection>
+  );
+};
+
+const styles = StyleSheet.create({
+  historyRow: {
+    marginBottom: 4,
+  },
+  historyDate: {
+    color: '#475569',
+    fontSize: 13,
+  },
+  historyValues: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 4,
+  },
+  historyValue: {
+    color: '#4c1d95',
+    fontSize: 13,
+    backgroundColor: '#ede9fe',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 8,
+    marginRight: 8,
+    marginBottom: 4,
+  },
+});
+
+export default LipidSection;

--- a/HealthLiveApp/src/modules/monitoring/components/sections/MetricSection.tsx
+++ b/HealthLiveApp/src/modules/monitoring/components/sections/MetricSection.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+
+type MetricSectionProps = {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+};
+
+const MetricSection: React.FC<MetricSectionProps> = ({title, description, children}) => (
+  <View style={styles.container}>
+    <Text style={styles.title}>{title}</Text>
+    {description ? <Text style={styles.description}>{description}</Text> : null}
+    {children}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 4,
+  },
+  description: {
+    fontSize: 13,
+    color: '#475569',
+    marginBottom: 12,
+  },
+});
+
+export default MetricSection;

--- a/HealthLiveApp/src/modules/monitoring/domain/index.ts
+++ b/HealthLiveApp/src/modules/monitoring/domain/index.ts
@@ -1,0 +1,2 @@
+export * from './metrics';
+export * from './thresholds';

--- a/HealthLiveApp/src/modules/monitoring/domain/metrics.ts
+++ b/HealthLiveApp/src/modules/monitoring/domain/metrics.ts
@@ -1,0 +1,58 @@
+export type MetricKind =
+  | 'bloodPressure'
+  | 'glucose'
+  | 'lipids'
+  | 'bodyComposition';
+
+export type MetricRecordBase = {
+  id: string;
+  recordedAt: string; // ISO string
+  note?: string;
+};
+
+export type BloodPressureRecord = MetricRecordBase & {
+  systolic: number;
+  diastolic: number;
+  pulse?: number;
+};
+
+export type GlucoseContext = 'ayunas' | 'postprandial' | 'aleatoria';
+
+export type GlucoseRecord = MetricRecordBase & {
+  value: number;
+  context: GlucoseContext;
+};
+
+export type LipidRecord = MetricRecordBase & {
+  totalCholesterol: number;
+  hdl: number;
+  ldl: number;
+  triglycerides: number;
+};
+
+export type BodyCompositionRecord = MetricRecordBase & {
+  weightKg: number;
+  heightCm: number;
+  bmi: number;
+};
+
+export type MetricRecordMap = {
+  bloodPressure: BloodPressureRecord;
+  glucose: GlucoseRecord;
+  lipids: LipidRecord;
+  bodyComposition: BodyCompositionRecord;
+};
+
+export const METRIC_STORAGE_KEYS: Record<MetricKind, string> = {
+  bloodPressure: '@healthlive/metrics/blood-pressure',
+  glucose: '@healthlive/metrics/glucose',
+  lipids: '@healthlive/metrics/lipids',
+  bodyComposition: '@healthlive/metrics/body-composition',
+};
+
+export const createMetricId = () => `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+
+export const sortByDate = <T extends MetricRecordBase>(records: T[]): T[] =>
+  [...records].sort((a, b) =>
+    new Date(a.recordedAt).getTime() - new Date(b.recordedAt).getTime(),
+  );

--- a/HealthLiveApp/src/modules/monitoring/domain/thresholds.ts
+++ b/HealthLiveApp/src/modules/monitoring/domain/thresholds.ts
@@ -1,0 +1,118 @@
+import type {
+  BloodPressureRecord,
+  BodyCompositionRecord,
+  GlucoseRecord,
+  LipidRecord,
+  MetricKind,
+  MetricRecordMap,
+} from './metrics';
+
+export type ThresholdConfig = {
+  bloodPressure: {
+    systolic: number;
+    diastolic: number;
+  };
+  glucose: {
+    value: number;
+  };
+  lipids: {
+    totalCholesterol: number;
+    ldl: number;
+    triglycerides: number;
+  };
+  bodyComposition: {
+    bmiHigh: number;
+    bmiLow: number;
+  };
+};
+
+export const DEFAULT_THRESHOLDS: ThresholdConfig = {
+  bloodPressure: {
+    systolic: 140,
+    diastolic: 90,
+  },
+  glucose: {
+    value: 140,
+  },
+  lipids: {
+    totalCholesterol: 200,
+    ldl: 130,
+    triglycerides: 150,
+  },
+  bodyComposition: {
+    bmiHigh: 30,
+    bmiLow: 18.5,
+  },
+};
+
+export type MetricAlert = {
+  recordId: string;
+  message: string;
+};
+
+type Evaluator<T> = (record: T) => string[];
+
+type EvaluatorMap = {
+  [K in MetricKind]: Evaluator<MetricRecordMap[K]>;
+};
+
+const bloodPressureEvaluator: Evaluator<BloodPressureRecord> = record => {
+  const alerts: string[] = [];
+  if (record.systolic >= DEFAULT_THRESHOLDS.bloodPressure.systolic) {
+    alerts.push('La presión sistólica supera el objetivo recomendado.');
+  }
+  if (record.diastolic >= DEFAULT_THRESHOLDS.bloodPressure.diastolic) {
+    alerts.push('La presión diastólica supera el objetivo recomendado.');
+  }
+  return alerts;
+};
+
+const glucoseEvaluator: Evaluator<GlucoseRecord> = record =>
+  record.value >= DEFAULT_THRESHOLDS.glucose.value
+    ? [`El nivel de glucosa (${record.value} mg/dL) requiere seguimiento.`]
+    : [];
+
+const lipidEvaluator: Evaluator<LipidRecord> = record => {
+  const alerts: string[] = [];
+  if (record.totalCholesterol >= DEFAULT_THRESHOLDS.lipids.totalCholesterol) {
+    alerts.push('El colesterol total se encuentra por encima del umbral.');
+  }
+  if (record.ldl >= DEFAULT_THRESHOLDS.lipids.ldl) {
+    alerts.push('El LDL supera el valor objetivo.');
+  }
+  if (record.triglycerides >= DEFAULT_THRESHOLDS.lipids.triglycerides) {
+    alerts.push('Los triglicéridos están elevados.');
+  }
+  return alerts;
+};
+
+const bodyEvaluator: Evaluator<BodyCompositionRecord> = record => {
+  if (record.bmi >= DEFAULT_THRESHOLDS.bodyComposition.bmiHigh) {
+    return ['El IMC indica obesidad, considere consultar con su especialista.'];
+  }
+  if (record.bmi < DEFAULT_THRESHOLDS.bodyComposition.bmiLow) {
+    return ['El IMC indica bajo peso, revise su plan nutricional.'];
+  }
+  return [];
+};
+
+const evaluators: EvaluatorMap = {
+  bloodPressure: bloodPressureEvaluator,
+  glucose: glucoseEvaluator,
+  lipids: lipidEvaluator,
+  bodyComposition: bodyEvaluator,
+};
+
+export const buildAlerts = <K extends MetricKind>(
+  metric: K,
+  records: MetricRecordMap[K][],
+): MetricAlert[] =>
+  records
+    .map(record => ({
+      recordId: record.id,
+      messages: evaluators[metric](record),
+    }))
+    .filter(item => item.messages.length > 0)
+    .flatMap(item =>
+      item.messages.map(message => ({recordId: item.recordId, message})),
+    );

--- a/HealthLiveApp/src/modules/monitoring/hooks/index.ts
+++ b/HealthLiveApp/src/modules/monitoring/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useMetricRecords';

--- a/HealthLiveApp/src/modules/monitoring/hooks/useMetricRecords.ts
+++ b/HealthLiveApp/src/modules/monitoring/hooks/useMetricRecords.ts
@@ -1,0 +1,48 @@
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import {createMetricId, MetricKind, MetricRecordBase, MetricRecordMap} from '../domain';
+import {MonitoringRepository} from '../storage';
+
+export type MetricRecordsHook<K extends MetricKind> = {
+  records: MetricRecordMap[K][];
+  loading: boolean;
+  addRecord: (record: Omit<MetricRecordMap[K], 'id'>) => Promise<void>;
+  refresh: () => Promise<void>;
+};
+
+export const useMetricRecords = <K extends MetricKind>(
+  metric: K,
+): MetricRecordsHook<K> => {
+  const repository = useMemo(() => new MonitoringRepository(), []);
+  const [records, setRecords] = useState<MetricRecordMap[K][]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadRecords = useCallback(async () => {
+    setLoading(true);
+    const stored = await repository.getRecords(metric);
+    setRecords(stored);
+    setLoading(false);
+  }, [metric, repository]);
+
+  useEffect(() => {
+    loadRecords();
+  }, [loadRecords]);
+
+  const addRecord = useCallback(
+    async (record: Omit<MetricRecordMap[K], 'id'>) => {
+      const newRecord = {
+        ...(record as MetricRecordBase),
+        id: createMetricId(),
+      } as MetricRecordMap[K];
+      const updated = await repository.addRecord(metric, newRecord);
+      setRecords(updated);
+    },
+    [metric, repository],
+  );
+
+  return {
+    records,
+    loading,
+    addRecord,
+    refresh: loadRecords,
+  };
+};

--- a/HealthLiveApp/src/modules/monitoring/index.ts
+++ b/HealthLiveApp/src/modules/monitoring/index.ts
@@ -1,1 +1,4 @@
 export {default as MonitoringDashboard} from './components/MonitoringDashboard';
+export * from './domain';
+export * from './hooks';
+export * from './storage';

--- a/HealthLiveApp/src/modules/monitoring/storage/MonitoringRepository.ts
+++ b/HealthLiveApp/src/modules/monitoring/storage/MonitoringRepository.ts
@@ -1,0 +1,68 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  METRIC_STORAGE_KEYS,
+  MetricKind,
+  MetricRecordBase,
+  MetricRecordMap,
+  sortByDate,
+} from '../domain';
+import SyncQueue from './SyncQueue';
+
+type WithoutId<T extends MetricRecordBase> = Omit<T, 'id'>;
+
+export default class MonitoringRepository {
+  constructor(
+    private storage = AsyncStorage,
+    private syncQueue = new SyncQueue(storage),
+  ) {}
+
+  async getRecords<K extends MetricKind>(metric: K): Promise<MetricRecordMap[K][]> {
+    const key = METRIC_STORAGE_KEYS[metric];
+    const stored = await this.storage.getItem(key);
+    if (!stored) {
+      return [];
+    }
+    try {
+      const parsed: MetricRecordMap[K][] = JSON.parse(stored);
+      return sortByDate(parsed);
+    } catch (error) {
+      console.warn('Error parsing metric records', error);
+      return [];
+    }
+  }
+
+  async addRecord<K extends MetricKind>(
+    metric: K,
+    record: MetricRecordMap[K],
+  ): Promise<MetricRecordMap[K][]> {
+    const key = METRIC_STORAGE_KEYS[metric];
+    const existing = await this.getRecords(metric);
+    const updated = sortByDate([...existing, record]);
+    await this.storage.setItem(key, JSON.stringify(updated));
+    await this.syncQueue.enqueue(metric, record);
+    return updated;
+  }
+
+  async persistDraft<K extends MetricKind>(
+    metric: K,
+    record: WithoutId<MetricRecordMap[K]>,
+  ) {
+    const key = `${METRIC_STORAGE_KEYS[metric]}:draft`;
+    await this.storage.setItem(key, JSON.stringify(record));
+  }
+
+  async readDraft<K extends MetricKind>(
+    metric: K,
+  ): Promise<WithoutId<MetricRecordMap[K]> | null> {
+    const key = `${METRIC_STORAGE_KEYS[metric]}:draft`;
+    const stored = await this.storage.getItem(key);
+    return stored ? JSON.parse(stored) : null;
+  }
+
+  async clearDraft<K extends MetricKind>(metric: K) {
+    const key = `${METRIC_STORAGE_KEYS[metric]}:draft`;
+    await this.storage.removeItem(key);
+  }
+}
+
+export type {WithoutId};

--- a/HealthLiveApp/src/modules/monitoring/storage/SyncQueue.ts
+++ b/HealthLiveApp/src/modules/monitoring/storage/SyncQueue.ts
@@ -1,0 +1,37 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type {MetricKind, MetricRecordBase} from '../domain';
+
+type SyncPayload = {
+  metric: MetricKind;
+  record: MetricRecordBase;
+  queuedAt: string;
+};
+
+const SYNC_QUEUE_KEY = '@healthlive/metrics/sync-queue';
+
+export default class SyncQueue {
+  constructor(private storage = AsyncStorage) {}
+
+  async enqueue(metric: MetricKind, record: MetricRecordBase) {
+    const existing = await this.storage.getItem(SYNC_QUEUE_KEY);
+    const payloads: SyncPayload[] = existing ? JSON.parse(existing) : [];
+    const nextPayloads = [
+      ...payloads,
+      {
+        metric,
+        record,
+        queuedAt: new Date().toISOString(),
+      },
+    ];
+    await this.storage.setItem(SYNC_QUEUE_KEY, JSON.stringify(nextPayloads));
+  }
+
+  async pending(): Promise<SyncPayload[]> {
+    const existing = await this.storage.getItem(SYNC_QUEUE_KEY);
+    return existing ? JSON.parse(existing) : [];
+  }
+
+  async clear() {
+    await this.storage.removeItem(SYNC_QUEUE_KEY);
+  }
+}

--- a/HealthLiveApp/src/modules/monitoring/storage/index.ts
+++ b/HealthLiveApp/src/modules/monitoring/storage/index.ts
@@ -1,0 +1,3 @@
+export {default as MonitoringRepository} from './MonitoringRepository';
+export {default as SyncQueue} from './SyncQueue';
+export type {WithoutId} from './MonitoringRepository';

--- a/HealthLiveApp/src/modules/monitoring/utils/date.ts
+++ b/HealthLiveApp/src/modules/monitoring/utils/date.ts
@@ -1,0 +1,12 @@
+export const formatShortDate = (isoDate: string) => {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return new Intl.DateTimeFormat('es-ES', {
+    day: '2-digit',
+    month: 'short',
+  })
+    .format(date)
+    .replace('.', '');
+};


### PR DESCRIPTION
## Summary
- add domain DTOs and threshold definitions for presión arterial, glucosa, lípidos y peso/IMC
- persist registros en AsyncStorage mediante un repositorio con cola de sincronización y hooks reutilizables
- renovar el dashboard de monitoreo con formularios validados, historiales con gráficos básicos y alertas configurables

## Testing
- npm run lint *(falla: ESLint 9 requiere archivo eslint.config.js en el proyecto base)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6cb02c84833186b2cfebb1be38e4