### PR TITLE
Add configurable reminder notifications and compliance tracking

### DIFF
--- a/HealthLiveApp/App.tsx
+++ b/HealthLiveApp/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {SafeAreaView, ScrollView, StatusBar, StyleSheet, View, Text} from 'react-native';
 import MonitoringDashboard from './src/modules/monitoring/components/MonitoringDashboard';
-import ReminderList from './src/modules/reminders/components/ReminderList';
+import ReminderCenter from './src/modules/reminders/components/ReminderCenter';
 import ProfileSummary from './src/modules/profile/components/ProfileSummary';
 
 function Section({title, children}: {title: string; children: React.ReactNode}) {
@@ -26,7 +26,7 @@ function App(): React.JSX.Element {
           <MonitoringDashboard />
         </Section>
         <Section title="Recordatorios personalizados">
-          <ReminderList />
+          <ReminderCenter />
         </Section>
         <Section title="Perfil de usuario">
           <ProfileSummary />

--- a/HealthLiveApp/package.json
+++ b/HealthLiveApp/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.74.3",
-    "@react-native-async-storage/async-storage": "^1.21.0"
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "react-native-push-notification": "^8.1.1"
   },
   "devDependencies": {
     "@react-native/eslint-config": "^0.74.0",

--- a/HealthLiveApp/src/modules/reminders/components/CompliancePanel.tsx
+++ b/HealthLiveApp/src/modules/reminders/components/CompliancePanel.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import {StyleSheet, Text, View, Pressable} from 'react-native';
+import {
+  DAILY_COMPLIANCE_TASKS,
+  WEEKLY_COMPLIANCE_TASKS,
+} from '../domain';
+import useComplianceChecklist from '../hooks/useComplianceChecklist';
+
+const CompliancePanel: React.FC = () => {
+  const {
+    daily,
+    weekly,
+    loading,
+    dailyCompletion,
+    weeklyCompletion,
+    toggleDaily,
+    toggleWeekly,
+  } = useComplianceChecklist();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Panel de cumplimiento</Text>
+      <Text style={styles.subtitle}>
+        Lleva un control diario y semanal de tus hábitos clave y celebra cada logro.
+      </Text>
+      <View style={styles.progressRow}>
+        <View style={styles.progressCard}>
+          <Text style={styles.progressLabel}>Cumplimiento diario</Text>
+          <Text style={styles.progressValue}>{dailyCompletion}%</Text>
+        </View>
+        <View style={styles.progressCard}>
+          <Text style={styles.progressLabel}>Cumplimiento semanal</Text>
+          <Text style={styles.progressValue}>{weeklyCompletion}%</Text>
+        </View>
+      </View>
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Checklist diario</Text>
+        {DAILY_COMPLIANCE_TASKS.map(task => (
+          <ChecklistItem
+            key={task.id}
+            label={task.label}
+            description={task.description}
+            checked={!!daily[task.id]}
+            disabled={loading}
+            onPress={() => toggleDaily(task.id)}
+          />
+        ))}
+      </View>
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Checklist semanal</Text>
+        {WEEKLY_COMPLIANCE_TASKS.map(task => (
+          <ChecklistItem
+            key={task.id}
+            label={task.label}
+            description={task.description}
+            checked={!!weekly[task.id]}
+            disabled={loading}
+            onPress={() => toggleWeekly(task.id)}
+          />
+        ))}
+      </View>
+    </View>
+  );
+};
+
+type ChecklistItemProps = {
+  label: string;
+  description: string;
+  checked: boolean;
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+const ChecklistItem: React.FC<ChecklistItemProps> = ({
+  label,
+  description,
+  checked,
+  onPress,
+  disabled,
+}) => {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      style={[styles.item, checked && styles.itemChecked, disabled && styles.itemDisabled]}
+    >
+      <View style={[styles.checkbox, checked && styles.checkboxChecked]}>
+        {checked && <Text style={styles.checkboxMark}>✓</Text>}
+      </View>
+      <View style={styles.itemContent}>
+        <Text style={styles.itemLabel}>{label}</Text>
+        <Text style={styles.itemDescription}>{description}</Text>
+      </View>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 24,
+    padding: 16,
+    backgroundColor: '#ecfeff',
+    borderRadius: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#0f172a',
+  },
+  subtitle: {
+    marginTop: 4,
+    color: '#334155',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  progressRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 16,
+  },
+  progressCard: {
+    flex: 1,
+    backgroundColor: '#cffafe',
+    borderRadius: 12,
+    padding: 12,
+  },
+  progressLabel: {
+    color: '#0e7490',
+    fontSize: 12,
+    textTransform: 'uppercase',
+  },
+  progressValue: {
+    color: '#0f172a',
+    fontSize: 20,
+    fontWeight: '700',
+    marginTop: 4,
+  },
+  section: {
+    marginTop: 20,
+  },
+  sectionTitle: {
+    color: '#0f172a',
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#bae6fd',
+    marginBottom: 10,
+    backgroundColor: '#f8fafc',
+  },
+  itemChecked: {
+    backgroundColor: '#ccfbf1',
+    borderColor: '#14b8a6',
+  },
+  itemDisabled: {
+    opacity: 0.6,
+  },
+  checkbox: {
+    width: 24,
+    height: 24,
+    borderRadius: 8,
+    borderWidth: 2,
+    borderColor: '#0891b2',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+    backgroundColor: '#ecfeff',
+  },
+  checkboxChecked: {
+    backgroundColor: '#14b8a6',
+    borderColor: '#0f766e',
+  },
+  checkboxMark: {
+    color: '#f8fafc',
+    fontWeight: '700',
+  },
+  itemContent: {
+    flex: 1,
+  },
+  itemLabel: {
+    color: '#0f172a',
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  itemDescription: {
+    color: '#475569',
+    marginTop: 4,
+    fontSize: 12,
+    lineHeight: 18,
+  },
+});
+
+export default CompliancePanel;

--- a/HealthLiveApp/src/modules/reminders/components/ReminderCenter.tsx
+++ b/HealthLiveApp/src/modules/reminders/components/ReminderCenter.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {View} from 'react-native';
+import ReminderList from './ReminderList';
+import ReminderSettingsPanel from './ReminderSettingsPanel';
+import CompliancePanel from './CompliancePanel';
+import useReminderPreferences from '../hooks/useReminderPreferences';
+import useReminderNotifications from '../hooks/useReminderNotifications';
+
+const ReminderCenter: React.FC = () => {
+  const {preferences, loading, updatePreference} = useReminderPreferences();
+  useReminderNotifications(preferences, !loading);
+
+  return (
+    <View>
+      <ReminderList preferences={preferences} loading={loading} />
+      <ReminderSettingsPanel preferences={preferences} onUpdate={updatePreference} />
+      <CompliancePanel />
+    </View>
+  );
+};
+
+export default ReminderCenter;

--- a/HealthLiveApp/src/modules/reminders/components/ReminderList.tsx
+++ b/HealthLiveApp/src/modules/reminders/components/ReminderList.tsx
@@ -1,35 +1,66 @@
 import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+import {ActivityIndicator, StyleSheet, Text, View} from 'react-native';
+import {ReminderPreference, SOUND_LABELS} from '../domain';
+import {describeSchedule} from '../utils/time';
 
-type Reminder = {
-  id: string;
-  title: string;
-  schedule: string;
+type ReminderListProps = {
+  preferences: ReminderPreference[];
+  loading?: boolean;
 };
 
-const reminders: Reminder[] = [
-  {id: '1', title: 'Tomar medicación matutina', schedule: '07:30 - Todos los días'},
-  {id: '2', title: 'Sesión de estiramientos', schedule: '12:00 - Lunes a Viernes'},
-  {id: '3', title: 'Revisión de hidratación', schedule: 'Cada 2 horas'},
-];
-
-const ReminderList: React.FC = () => (
-  <View>
-    {reminders.map(reminder => (
-      <View key={reminder.id} style={styles.reminderCard}>
-        <Text style={styles.reminderTitle}>{reminder.title}</Text>
-        <Text style={styles.reminderSchedule}>{reminder.schedule}</Text>
+const ReminderList: React.FC<ReminderListProps> = ({preferences, loading}) => {
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="small" color="#0284c7" />
+        <Text style={styles.loadingText}>Cargando recordatorios personalizados…</Text>
       </View>
-    ))}
-  </View>
-);
+    );
+  }
+
+  return (
+    <View>
+      {preferences.map(preference => (
+        <View
+          key={preference.id}
+          style={[styles.reminderCard, !preference.enabled && styles.reminderDisabled]}
+        >
+          <Text style={styles.reminderTitle}>{preference.title}</Text>
+          <Text style={styles.reminderSchedule}>{describeSchedule(preference)}</Text>
+          <View style={styles.metaRow}>
+            <Text style={styles.metaLabel}>
+              Sonido:
+              <Text style={styles.metaValue}> {SOUND_LABELS[preference.sound]}</Text>
+            </Text>
+            <Text style={styles.metaStatus}>
+              {preference.enabled ? 'Activo' : 'En pausa'}
+            </Text>
+          </View>
+          <Text style={styles.reminderDescription}>{preference.description}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
+  loadingContainer: {
+    alignItems: 'center',
+    paddingVertical: 16,
+  },
+  loadingText: {
+    marginTop: 8,
+    color: '#475569',
+    fontSize: 14,
+  },
   reminderCard: {
     backgroundColor: '#fef3c7',
     borderRadius: 12,
     padding: 12,
     marginBottom: 12,
+  },
+  reminderDisabled: {
+    opacity: 0.6,
   },
   reminderTitle: {
     fontSize: 16,
@@ -40,6 +71,30 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#b45309',
     marginTop: 4,
+  },
+  reminderDescription: {
+    marginTop: 8,
+    color: '#854d0e',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  metaRow: {
+    marginTop: 8,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  metaLabel: {
+    color: '#92400e',
+    fontSize: 12,
+  },
+  metaValue: {
+    fontWeight: '600',
+  },
+  metaStatus: {
+    color: '#92400e',
+    fontWeight: '600',
+    fontSize: 12,
   },
 });
 

--- a/HealthLiveApp/src/modules/reminders/components/ReminderSettingsPanel.tsx
+++ b/HealthLiveApp/src/modules/reminders/components/ReminderSettingsPanel.tsx
@@ -1,0 +1,291 @@
+import React, {useEffect, useState} from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  DEFAULT_REMINDER_PREFERENCES,
+  NOTIFICATION_TONES,
+  ReminderPreference,
+  ReminderPreferenceUpdate,
+  ReminderType,
+  SOUND_LABELS,
+} from '../domain';
+import {normalizeFrequencyMinutes, normalizeTimeString} from '../utils/time';
+
+type ReminderSettingsPanelProps = {
+  preferences: ReminderPreference[];
+  onUpdate: (id: ReminderType, updates: ReminderPreferenceUpdate) => Promise<void>;
+};
+
+type FormState = Record<
+  ReminderType,
+  {
+    startTime: string;
+    endTime: string;
+    frequencyMinutes: string;
+  }
+>;
+
+const toneOrder = NOTIFICATION_TONES.map(tone => tone.id);
+
+function createInitialState(preferences: ReminderPreference[]): FormState {
+  return preferences.reduce<FormState>((state, preference) => {
+    state[preference.id] = {
+      startTime: preference.startTime,
+      endTime: preference.endTime,
+      frequencyMinutes: preference.frequencyMinutes.toString(),
+    };
+    return state;
+  }, {} as FormState);
+}
+
+const ReminderSettingsPanel: React.FC<ReminderSettingsPanelProps> = ({
+  preferences,
+  onUpdate,
+}) => {
+  const [formState, setFormState] = useState<FormState>(() =>
+    createInitialState(preferences),
+  );
+
+  useEffect(() => {
+    setFormState(createInitialState(preferences));
+  }, [preferences]);
+
+  const handleTimeChange = (
+    id: ReminderType,
+    field: 'startTime' | 'endTime',
+    value: string,
+  ) => {
+    setFormState(prev => ({
+      ...prev,
+      [id]: {...prev[id], [field]: value},
+    }));
+  };
+
+  const commitTimeChange = async (
+    id: ReminderType,
+    field: 'startTime' | 'endTime',
+  ) => {
+    const defaults = DEFAULT_REMINDER_PREFERENCES.find(item => item.id === id);
+    const fallback = defaults?.[field] ?? '08:00';
+    const currentValue = formState[id]?.[field] ?? fallback;
+    const normalized = normalizeTimeString(currentValue, fallback);
+    setFormState(prev => ({
+      ...prev,
+      [id]: {...prev[id], [field]: normalized},
+    }));
+    try {
+      await onUpdate(id, {[field]: normalized});
+    } catch (error) {
+      console.warn('No se pudo guardar el horario del recordatorio', error);
+    }
+  };
+
+  const handleFrequencyChange = (id: ReminderType, value: string) => {
+    setFormState(prev => ({
+      ...prev,
+      [id]: {...prev[id], frequencyMinutes: value.replace(/[^0-9]/g, '')},
+    }));
+  };
+
+  const commitFrequencyChange = async (id: ReminderType) => {
+    const defaults = DEFAULT_REMINDER_PREFERENCES.find(item => item.id === id);
+    const fallback = defaults?.frequencyMinutes ?? 60;
+    const rawValue = formState[id]?.frequencyMinutes ?? fallback.toString();
+    const parsed = parseInt(rawValue, 10);
+    const normalized = normalizeFrequencyMinutes(parsed, fallback);
+    setFormState(prev => ({
+      ...prev,
+      [id]: {...prev[id], frequencyMinutes: normalized.toString()},
+    }));
+    try {
+      await onUpdate(id, {frequencyMinutes: normalized});
+    } catch (error) {
+      console.warn('No se pudo guardar la frecuencia del recordatorio', error);
+    }
+  };
+
+  const advanceTone = async (id: ReminderType, current: ReminderPreference['sound']) => {
+    const index = toneOrder.indexOf(current);
+    const next = toneOrder[(index + 1) % toneOrder.length];
+    try {
+      await onUpdate(id, {sound: next});
+    } catch (error) {
+      console.warn('No se pudo actualizar el tono del recordatorio', error);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Ajustes de recordatorios</Text>
+      <Text style={styles.subtitle}>
+        Personaliza el horario, la frecuencia y el tono de cada hábito para que
+        se adapten a tu rutina diaria.
+      </Text>
+      {preferences.map(preference => (
+        <View key={preference.id} style={styles.card}>
+          <View style={styles.cardHeader}>
+            <View style={{flex: 1}}>
+              <Text style={styles.cardTitle}>{preference.title}</Text>
+              <Text style={styles.cardDescription}>{preference.description}</Text>
+            </View>
+            <Switch
+              value={preference.enabled}
+              onValueChange={value => {
+                onUpdate(preference.id, {enabled: value}).catch(error => {
+                  console.warn('No se pudo actualizar el estado del recordatorio', error);
+                });
+              }}
+            />
+          </View>
+          <View style={styles.fieldRow}>
+            <View style={styles.field}>
+              <Text style={styles.fieldLabel}>Desde</Text>
+              <TextInput
+                value={formState[preference.id]?.startTime ?? ''}
+                onChangeText={value => handleTimeChange(preference.id, 'startTime', value)}
+                onBlur={() => commitTimeChange(preference.id, 'startTime')}
+                placeholder="HH:MM"
+                keyboardType="numeric"
+                style={styles.input}
+                maxLength={5}
+              />
+            </View>
+            <View style={styles.field}>
+              <Text style={styles.fieldLabel}>Hasta</Text>
+              <TextInput
+                value={formState[preference.id]?.endTime ?? ''}
+                onChangeText={value => handleTimeChange(preference.id, 'endTime', value)}
+                onBlur={() => commitTimeChange(preference.id, 'endTime')}
+                placeholder="HH:MM"
+                keyboardType="numeric"
+                style={styles.input}
+                maxLength={5}
+              />
+            </View>
+          </View>
+          <View style={styles.fieldRow}>
+            <View style={[styles.field, styles.frequencyField]}>
+              <Text style={styles.fieldLabel}>Frecuencia (min)</Text>
+              <TextInput
+                value={formState[preference.id]?.frequencyMinutes ?? ''}
+                onChangeText={value => handleFrequencyChange(preference.id, value)}
+                onBlur={() => commitFrequencyChange(preference.id)}
+                keyboardType="numeric"
+                style={styles.input}
+                maxLength={4}
+              />
+            </View>
+            <Pressable
+              onPress={() => {
+                advanceTone(preference.id, preference.sound).catch(() => undefined);
+              }}
+              style={styles.toneSelector}
+            >
+              <Text style={styles.toneLabel}>Tono</Text>
+              <Text style={styles.toneValue}>{SOUND_LABELS[preference.sound]}</Text>
+              <Text style={styles.toneHint}>Tocar para cambiar</Text>
+            </Pressable>
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 8,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#0f172a',
+  },
+  subtitle: {
+    marginTop: 4,
+    color: '#475569',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  card: {
+    backgroundColor: '#e0f2fe',
+    borderRadius: 14,
+    padding: 16,
+    marginTop: 16,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#0c4a6e',
+  },
+  cardDescription: {
+    marginTop: 4,
+    color: '#0c4a6e',
+    opacity: 0.8,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  fieldRow: {
+    flexDirection: 'row',
+    marginTop: 16,
+    gap: 12,
+  },
+  field: {
+    flex: 1,
+  },
+  frequencyField: {
+    flex: 0.7,
+  },
+  fieldLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#0369a1',
+    marginBottom: 4,
+  },
+  input: {
+    backgroundColor: '#f8fafc',
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    fontSize: 14,
+    color: '#0f172a',
+    borderWidth: 1,
+    borderColor: '#bae6fd',
+  },
+  toneSelector: {
+    flex: 1,
+    backgroundColor: '#0ea5e9',
+    borderRadius: 12,
+    padding: 12,
+    justifyContent: 'center',
+  },
+  toneLabel: {
+    color: '#e0f2fe',
+    fontSize: 12,
+    textTransform: 'uppercase',
+  },
+  toneValue: {
+    color: '#f8fafc',
+    fontWeight: '700',
+    marginTop: 4,
+    fontSize: 15,
+  },
+  toneHint: {
+    color: '#bae6fd',
+    fontSize: 11,
+    marginTop: 2,
+  },
+});
+
+export default ReminderSettingsPanel;

--- a/HealthLiveApp/src/modules/reminders/domain/index.ts
+++ b/HealthLiveApp/src/modules/reminders/domain/index.ts
@@ -1,0 +1,140 @@
+export type ReminderType = 'movement' | 'hydration' | 'measurements' | 'exercise';
+
+export const NOTIFICATION_TONES = [
+  {id: 'default', label: 'Predeterminado'},
+  {id: 'focus', label: 'Campana suave'},
+  {id: 'energetic', label: 'Energía matutina'},
+  {id: 'calm', label: 'Olas tranquilas'},
+] as const;
+
+export type NotificationTone = typeof NOTIFICATION_TONES[number]['id'];
+
+export type ReminderPreference = {
+  id: ReminderType;
+  title: string;
+  description: string;
+  startTime: string;
+  endTime: string;
+  frequencyMinutes: number;
+  sound: NotificationTone;
+  enabled: boolean;
+};
+
+export type ReminderPreferenceUpdate = Partial<Omit<ReminderPreference, 'id'>>;
+
+export const REMINDER_PREFERENCES_STORAGE_KEY = '@healthlive:reminder-preferences';
+export const COMPLIANCE_STORAGE_KEY = '@healthlive:reminder-compliance';
+
+export const DEFAULT_REMINDER_PREFERENCES: ReminderPreference[] = [
+  {
+    id: 'movement',
+    title: 'Moverse cada hora',
+    description: 'Recibe avisos suaves para levantarte, estirarte y reactivar tu circulación.',
+    startTime: '09:00',
+    endTime: '21:00',
+    frequencyMinutes: 60,
+    sound: 'energetic',
+    enabled: true,
+  },
+  {
+    id: 'hydration',
+    title: 'Beber agua',
+    description: 'Hidratación regular a lo largo del día con recordatorios motivadores.',
+    startTime: '08:00',
+    endTime: '20:00',
+    frequencyMinutes: 120,
+    sound: 'calm',
+    enabled: true,
+  },
+  {
+    id: 'measurements',
+    title: 'Tomar mediciones',
+    description: 'Registra tus signos vitales clave y mantén tu historial al día.',
+    startTime: '07:30',
+    endTime: '21:00',
+    frequencyMinutes: 720,
+    sound: 'focus',
+    enabled: true,
+  },
+  {
+    id: 'exercise',
+    title: 'Ejercicios planificados',
+    description: 'Prepárate para las rutinas sugeridas y mantén tu plan en marcha.',
+    startTime: '18:00',
+    endTime: '19:00',
+    frequencyMinutes: 1440,
+    sound: 'default',
+    enabled: true,
+  },
+];
+
+export type ComplianceTask = {
+  id: string;
+  label: string;
+  description: string;
+  type: 'daily' | 'weekly';
+  relatedReminder?: ReminderType;
+};
+
+export const DAILY_COMPLIANCE_TASKS: ComplianceTask[] = [
+  {
+    id: 'movement-check',
+    type: 'daily',
+    label: 'Movimiento activo',
+    description: 'Marca cuando te hayas levantado y movido al menos una vez cada hora.',
+    relatedReminder: 'movement',
+  },
+  {
+    id: 'hydration-check',
+    type: 'daily',
+    label: 'Hidratación cumplida',
+    description: 'Confirma que bebiste agua en todos los avisos programados.',
+    relatedReminder: 'hydration',
+  },
+  {
+    id: 'measurements-check',
+    type: 'daily',
+    label: 'Registro de mediciones',
+    description: 'Indica si actualizaste tus signos vitales del día.',
+    relatedReminder: 'measurements',
+  },
+  {
+    id: 'exercise-check',
+    type: 'daily',
+    label: 'Rutina completada',
+    description: 'Señala cuando terminaste los ejercicios planificados.',
+    relatedReminder: 'exercise',
+  },
+];
+
+export const WEEKLY_COMPLIANCE_TASKS: ComplianceTask[] = [
+  {
+    id: 'planning-review',
+    type: 'weekly',
+    label: 'Revisión de la semana',
+    description: 'Evalúa tus progresos y ajusta el plan de ejercicios.',
+  },
+  {
+    id: 'measurements-review',
+    type: 'weekly',
+    label: 'Comparar mediciones',
+    description: 'Analiza tendencias de signos vitales y comenta con tu especialista.',
+  },
+  {
+    id: 'selfcare-session',
+    type: 'weekly',
+    label: 'Sesión de autocuidado',
+    description: 'Regálate una sesión de respiración, yoga o relajación guiada.',
+  },
+];
+
+export const SOUND_LABELS: Record<NotificationTone, string> = NOTIFICATION_TONES.reduce(
+  (labels, tone) => {
+    return {...labels, [tone.id]: tone.label};
+  },
+  {} as Record<NotificationTone, string>,
+);
+
+export const MIN_FREQUENCY_MINUTES = 15;
+
+export const MAX_REMINDERS_PER_DAY = 24;

--- a/HealthLiveApp/src/modules/reminders/hooks/useComplianceChecklist.ts
+++ b/HealthLiveApp/src/modules/reminders/hooks/useComplianceChecklist.ts
@@ -1,0 +1,145 @@
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  COMPLIANCE_STORAGE_KEY,
+  DAILY_COMPLIANCE_TASKS,
+  WEEKLY_COMPLIANCE_TASKS,
+} from '../domain';
+
+export type ChecklistStatus = {
+  daily: Record<string, boolean>;
+  weekly: Record<string, boolean>;
+  dailyCompletion: number;
+  weeklyCompletion: number;
+  toggleDaily: (id: string) => void;
+  toggleWeekly: (id: string) => void;
+  loading: boolean;
+};
+
+type StoredCompliance = {
+  daily: Record<string, Record<string, boolean>>;
+  weekly: Record<string, Record<string, boolean>>;
+};
+
+function createEmptyStatus(ids: string[]): Record<string, boolean> {
+  return ids.reduce<Record<string, boolean>>((acc, id) => {
+    acc[id] = false;
+    return acc;
+  }, {});
+}
+
+function getTodayKey(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+function getISOWeekKey(date = new Date()): string {
+  const tmp = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = tmp.getUTCDay() || 7;
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
+  const weekNum = Math.ceil(((tmp.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${tmp.getUTCFullYear()}-W${weekNum.toString().padStart(2, '0')}`;
+}
+
+export default function useComplianceChecklist(): ChecklistStatus {
+  const [loading, setLoading] = useState(true);
+  const [dailyStatus, setDailyStatus] = useState<Record<string, boolean>>(() =>
+    createEmptyStatus(DAILY_COMPLIANCE_TASKS.map(task => task.id)),
+  );
+  const [weeklyStatus, setWeeklyStatus] = useState<Record<string, boolean>>(() =>
+    createEmptyStatus(WEEKLY_COMPLIANCE_TASKS.map(task => task.id)),
+  );
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      const todayKey = getTodayKey();
+      const weekKey = getISOWeekKey();
+      try {
+        const stored = await AsyncStorage.getItem(COMPLIANCE_STORAGE_KEY);
+        if (!stored) {
+          setDailyStatus(createEmptyStatus(DAILY_COMPLIANCE_TASKS.map(task => task.id)));
+          setWeeklyStatus(createEmptyStatus(WEEKLY_COMPLIANCE_TASKS.map(task => task.id)));
+          setLoading(false);
+          return;
+        }
+        const parsed = JSON.parse(stored) as StoredCompliance;
+        const dailyForToday =
+          parsed.daily?.[todayKey] ??
+          createEmptyStatus(DAILY_COMPLIANCE_TASKS.map(task => task.id));
+        const weeklyForWeek =
+          parsed.weekly?.[weekKey] ??
+          createEmptyStatus(WEEKLY_COMPLIANCE_TASKS.map(task => task.id));
+        setDailyStatus(dailyForToday);
+        setWeeklyStatus(weeklyForWeek);
+      } catch (error) {
+        console.warn('Error al cargar el cumplimiento', error);
+        setDailyStatus(createEmptyStatus(DAILY_COMPLIANCE_TASKS.map(task => task.id)));
+        setWeeklyStatus(createEmptyStatus(WEEKLY_COMPLIANCE_TASKS.map(task => task.id)));
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  const persist = useCallback(
+    async (nextDaily: Record<string, boolean>, nextWeekly: Record<string, boolean>) => {
+      const payload: StoredCompliance = {
+        daily: {[getTodayKey()]: nextDaily},
+        weekly: {[getISOWeekKey()]: nextWeekly},
+      };
+      try {
+        await AsyncStorage.setItem(COMPLIANCE_STORAGE_KEY, JSON.stringify(payload));
+      } catch (error) {
+        console.warn('Error guardando el cumplimiento', error);
+      }
+    },
+    [],
+  );
+
+  const toggleDaily = useCallback(
+    async (id: string) => {
+      setDailyStatus(prev => {
+        const next = {...prev, [id]: !prev[id]};
+        persist(next, weeklyStatus).catch(() => undefined);
+        return next;
+      });
+    },
+    [persist, weeklyStatus],
+  );
+
+  const toggleWeekly = useCallback(
+    async (id: string) => {
+      setWeeklyStatus(prev => {
+        const next = {...prev, [id]: !prev[id]};
+        persist(dailyStatus, next).catch(() => undefined);
+        return next;
+      });
+    },
+    [dailyStatus, persist],
+  );
+
+  const dailyCompletion = useMemo(() => {
+    const total = DAILY_COMPLIANCE_TASKS.length || 1;
+    const achieved = Object.values(dailyStatus).filter(Boolean).length;
+    return Math.round((achieved / total) * 100);
+  }, [dailyStatus]);
+
+  const weeklyCompletion = useMemo(() => {
+    const total = WEEKLY_COMPLIANCE_TASKS.length || 1;
+    const achieved = Object.values(weeklyStatus).filter(Boolean).length;
+    return Math.round((achieved / total) * 100);
+  }, [weeklyStatus]);
+
+  return {
+    daily: dailyStatus,
+    weekly: weeklyStatus,
+    dailyCompletion,
+    weeklyCompletion,
+    toggleDaily,
+    toggleWeekly,
+    loading,
+  };
+}

--- a/HealthLiveApp/src/modules/reminders/hooks/useReminderNotifications.ts
+++ b/HealthLiveApp/src/modules/reminders/hooks/useReminderNotifications.ts
@@ -1,0 +1,19 @@
+import {useEffect} from 'react';
+import {ReminderPreference} from '../domain';
+import NotificationService from '../services/NotificationService';
+
+export default function useReminderNotifications(
+  preferences: ReminderPreference[],
+  ready: boolean,
+) {
+  useEffect(() => {
+    NotificationService.configure();
+  }, []);
+
+  useEffect(() => {
+    if (!ready) {
+      return;
+    }
+    NotificationService.syncReminderSchedules(preferences);
+  }, [preferences, ready]);
+}

--- a/HealthLiveApp/src/modules/reminders/hooks/useReminderPreferences.ts
+++ b/HealthLiveApp/src/modules/reminders/hooks/useReminderPreferences.ts
@@ -1,0 +1,69 @@
+import {useCallback, useEffect, useState} from 'react';
+import {
+  DEFAULT_REMINDER_PREFERENCES,
+  ReminderPreference,
+  ReminderPreferenceUpdate,
+  ReminderType,
+} from '../domain';
+import repository from '../storage/ReminderPreferencesRepository';
+
+export type ReminderPreferencesState = {
+  loading: boolean;
+  preferences: ReminderPreference[];
+  updatePreference: (
+    id: ReminderType,
+    updates: ReminderPreferenceUpdate,
+  ) => Promise<void>;
+  reload: () => Promise<void>;
+};
+
+function sortPreferences(preferences: ReminderPreference[]): ReminderPreference[] {
+  const order: ReminderType[] = ['movement', 'hydration', 'measurements', 'exercise'];
+  return [...preferences].sort(
+    (a, b) => order.indexOf(a.id) - order.indexOf(b.id),
+  );
+}
+
+export default function useReminderPreferences(): ReminderPreferencesState {
+  const [preferences, setPreferences] = useState<ReminderPreference[]>(
+    DEFAULT_REMINDER_PREFERENCES,
+  );
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const loaded = await repository.load();
+    setPreferences(sortPreferences(loaded));
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const updatePreference = useCallback(
+    async (id: ReminderType, updates: ReminderPreferenceUpdate) => {
+      let nextState: ReminderPreference[] = [];
+      setPreferences(prev => {
+        const next = prev.map(preference =>
+          preference.id === id ? {...preference, ...updates} : preference,
+        );
+        nextState = sortPreferences(next);
+        return nextState;
+      });
+      try {
+        await repository.save(nextState);
+      } catch (error) {
+        console.warn('Error persisting reminder preference', error);
+      }
+    },
+    [],
+  );
+
+  return {
+    loading,
+    preferences,
+    updatePreference,
+    reload: load,
+  };
+}

--- a/HealthLiveApp/src/modules/reminders/index.ts
+++ b/HealthLiveApp/src/modules/reminders/index.ts
@@ -1,1 +1,2 @@
 export {default as ReminderList} from './components/ReminderList';
+export {default as ReminderCenter} from './components/ReminderCenter';

--- a/HealthLiveApp/src/modules/reminders/services/NotificationService.ts
+++ b/HealthLiveApp/src/modules/reminders/services/NotificationService.ts
@@ -1,0 +1,103 @@
+import PushNotification, {Importance} from 'react-native-push-notification';
+import {Platform} from 'react-native';
+import {ReminderPreference} from '../domain';
+import {calculateDailySlots, formatMinutesAsTime} from '../utils/time';
+
+const CHANNEL_ID = 'healthlive-reminders';
+
+class NotificationService {
+  private configured = false;
+
+  configure() {
+    if (this.configured) {
+      return;
+    }
+
+    PushNotification.configure({
+      onNotification: notification => {
+        if (notification?.userInfo) {
+          // noop: placeholder for analytics or navigation hooks
+        }
+      },
+      requestPermissions: Platform.OS === 'ios',
+      popInitialNotification: true,
+    });
+
+    if (Platform.OS === 'android') {
+      PushNotification.createChannel(
+        {
+          channelId: CHANNEL_ID,
+          channelName: 'Recordatorios de hábitos saludables',
+          channelDescription:
+            'Notificaciones para hidratación, movimiento y rutinas planificadas.',
+          importance: Importance.HIGH,
+          playSound: true,
+          soundName: 'default',
+          vibrate: true,
+        },
+        created => {
+          if (!created) {
+            console.log('Canal de notificaciones existente reutilizado');
+          }
+        },
+      );
+    }
+
+    this.configured = true;
+  }
+
+  async syncReminderSchedules(preferences: ReminderPreference[]) {
+    this.configure();
+    PushNotification.cancelAllLocalNotifications();
+
+    preferences
+      .filter(preference => preference.enabled)
+      .forEach(preference => {
+        const slots = calculateDailySlots(preference);
+
+        slots.forEach((minutes, index) => {
+          const scheduledDate = this.buildDate(minutes);
+          PushNotification.localNotificationSchedule({
+            id: `${preference.id}-${index}`,
+            channelId: CHANNEL_ID,
+            message: preference.title,
+            date: scheduledDate,
+            allowWhileIdle: true,
+            repeatType: 'day',
+            userInfo: {
+              reminderId: preference.id,
+              scheduledTime: formatMinutesAsTime(minutes),
+            },
+            playSound: true,
+            soundName: this.resolveSoundName(preference.sound),
+            importance: Importance.HIGH,
+            title: 'Health Live',
+            subtitle: preference.description,
+          });
+        });
+      });
+  }
+
+  cancelAll() {
+    PushNotification.cancelAllLocalNotifications();
+  }
+
+  private buildDate(minutes: number): Date {
+    const now = new Date();
+    const target = new Date(now);
+    target.setHours(Math.floor(minutes / 60), minutes % 60, 0, 0);
+    if (target <= now) {
+      target.setDate(target.getDate() + 1);
+    }
+    return target;
+  }
+
+  private resolveSoundName(sound: ReminderPreference['sound']): string | undefined {
+    if (sound === 'default') {
+      return 'default';
+    }
+    return `${sound}.mp3`;
+  }
+}
+
+export default new NotificationService();

--- a/HealthLiveApp/src/modules/reminders/storage/ReminderPreferencesRepository.ts
+++ b/HealthLiveApp/src/modules/reminders/storage/ReminderPreferencesRepository.ts
@@ -1,0 +1,82 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  DEFAULT_REMINDER_PREFERENCES,
+  REMINDER_PREFERENCES_STORAGE_KEY,
+  ReminderPreference,
+  ReminderPreferenceUpdate,
+  ReminderType,
+  SOUND_LABELS,
+} from '../domain';
+import {normalizeFrequencyMinutes, normalizeTimeString} from '../utils/time';
+
+const repositoryInstance = new (class ReminderPreferencesRepository {
+  async load(): Promise<ReminderPreference[]> {
+    try {
+      const stored = await AsyncStorage.getItem(REMINDER_PREFERENCES_STORAGE_KEY);
+      if (!stored) {
+        return DEFAULT_REMINDER_PREFERENCES;
+      }
+      const parsed = JSON.parse(stored) as ReminderPreference[];
+      if (!Array.isArray(parsed)) {
+        return DEFAULT_REMINDER_PREFERENCES;
+      }
+      return DEFAULT_REMINDER_PREFERENCES.map(defaultPreference => {
+        const saved = parsed.find(item => item.id === defaultPreference.id);
+        if (!saved) {
+          return defaultPreference;
+        }
+        return sanitizePreference(defaultPreference.id, {...defaultPreference, ...saved});
+      });
+    } catch (error) {
+      console.warn('Error loading reminder preferences', error);
+      return DEFAULT_REMINDER_PREFERENCES;
+    }
+  }
+
+  async save(preferences: ReminderPreference[]): Promise<void> {
+    try {
+      const sanitized = preferences.map(preference =>
+        sanitizePreference(preference.id, preference),
+      );
+      await AsyncStorage.setItem(
+        REMINDER_PREFERENCES_STORAGE_KEY,
+        JSON.stringify(sanitized),
+      );
+    } catch (error) {
+      console.warn('Error saving reminder preferences', error);
+    }
+  }
+})();
+
+function sanitizePreference(
+  id: ReminderType,
+  preference: ReminderPreference,
+): ReminderPreference {
+  const fallback = DEFAULT_REMINDER_PREFERENCES.find(item => item.id === id);
+  if (!fallback) {
+    return preference;
+  }
+  const startTime = normalizeTimeString(preference.startTime, fallback.startTime);
+  const endTime = normalizeTimeString(preference.endTime, fallback.endTime);
+  const frequencyMinutes = normalizeFrequencyMinutes(
+    preference.frequencyMinutes,
+    fallback.frequencyMinutes,
+  );
+
+  const sound = Object.prototype.hasOwnProperty.call(SOUND_LABELS, preference.sound)
+    ? preference.sound
+    : fallback.sound;
+
+  return {
+    ...fallback,
+    ...preference,
+    id,
+    startTime,
+    endTime,
+    frequencyMinutes,
+    sound,
+  };
+}
+
+export type {ReminderPreference, ReminderPreferenceUpdate, ReminderType};
+export default repositoryInstance;

--- a/HealthLiveApp/src/modules/reminders/utils/time.ts
+++ b/HealthLiveApp/src/modules/reminders/utils/time.ts
@@ -1,0 +1,122 @@
+import {
+  DEFAULT_REMINDER_PREFERENCES,
+  MAX_REMINDERS_PER_DAY,
+  MIN_FREQUENCY_MINUTES,
+  ReminderPreference,
+} from '../domain';
+
+const MINUTES_IN_DAY = 24 * 60;
+
+export const TIME_FORMAT_REGEX = /^([01]?\d|2[0-3]):([0-5]\d)$/;
+
+export function parseTimeString(value: string): number | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  const match = TIME_FORMAT_REGEX.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    return null;
+  }
+  return hours * 60 + minutes;
+}
+
+export function formatMinutesAsTime(totalMinutes: number): string {
+  const normalized = ((totalMinutes % MINUTES_IN_DAY) + MINUTES_IN_DAY) % MINUTES_IN_DAY;
+  const hours = Math.floor(normalized / 60);
+  const minutes = normalized % 60;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+}
+
+export function normalizeTimeString(
+  rawValue: string,
+  fallback: string,
+): string {
+  const parsed = parseTimeString(rawValue);
+  if (parsed === null) {
+    return fallback;
+  }
+  return formatMinutesAsTime(parsed);
+}
+
+export function normalizeFrequencyMinutes(
+  value: number,
+  fallback: number,
+): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  if (value < MIN_FREQUENCY_MINUTES) {
+    return MIN_FREQUENCY_MINUTES;
+  }
+  if (value > MINUTES_IN_DAY) {
+    return MINUTES_IN_DAY;
+  }
+  return Math.round(value);
+}
+
+export function getDefaultPreferenceById(id: ReminderPreference['id']): ReminderPreference {
+  return DEFAULT_REMINDER_PREFERENCES.find(item => item.id === id) ?? DEFAULT_REMINDER_PREFERENCES[0];
+}
+
+export function calculateDailySlots(preference: ReminderPreference): number[] {
+  const start = parseTimeString(preference.startTime);
+  const end = parseTimeString(preference.endTime);
+  const defaults = getDefaultPreferenceById(preference.id);
+  const normalizedStart = start ?? parseTimeString(defaults.startTime) ?? 8 * 60;
+  const normalizedEnd = end ?? parseTimeString(defaults.endTime) ?? normalizedStart;
+  const normalizedFrequency = normalizeFrequencyMinutes(
+    preference.frequencyMinutes,
+    defaults.frequencyMinutes,
+  );
+
+  const slots: number[] = [normalizedStart % MINUTES_IN_DAY];
+  const windowRange =
+    normalizedStart <= normalizedEnd
+      ? normalizedEnd - normalizedStart
+      : MINUTES_IN_DAY - (normalizedStart - normalizedEnd);
+
+  if (normalizedFrequency >= MINUTES_IN_DAY || windowRange === 0) {
+    return slots;
+  }
+
+  let elapsed = normalizedFrequency;
+  let iterations = 0;
+  const maxIterations = Math.ceil(MINUTES_IN_DAY / normalizedFrequency);
+  while (elapsed <= windowRange && iterations < maxIterations) {
+    const next = (normalizedStart + elapsed) % MINUTES_IN_DAY;
+    slots.push(next);
+    elapsed += normalizedFrequency;
+    iterations += 1;
+  }
+
+  return slots.slice(0, Math.max(1, Math.min(slots.length, MAX_REMINDERS_PER_DAY)));
+}
+
+export function describeSchedule(preference: ReminderPreference): string {
+  if (!preference.enabled) {
+    return 'Recordatorio desactivado temporalmente';
+  }
+  const slots = calculateDailySlots(preference);
+  const first = formatMinutesAsTime(slots[0]);
+  if (slots.length === 1) {
+    const repeatEvery = normalizeFrequencyMinutes(
+      preference.frequencyMinutes,
+      getDefaultPreferenceById(preference.id).frequencyMinutes,
+    );
+    if (repeatEvery >= MINUTES_IN_DAY) {
+      return `Todos los días a las ${first}`;
+    }
+    return `Desde las ${first} cada ${repeatEvery} minutos`;
+  }
+  const last = formatMinutesAsTime(slots[slots.length - 1]);
+  return `De ${first} a ${last} cada ${normalizeFrequencyMinutes(
+    preference.frequencyMinutes,
+    getDefaultPreferenceById(preference.id).frequencyMinutes,
+  )} minutos`;
+}


### PR DESCRIPTION
## Summary
- integrate a local notification service with daily schedule generation for each reminder
- persist customizable reminder preferences in AsyncStorage and expose them through new hooks and settings UI
- add a compliance dashboard with daily and weekly checklists to track adherence

## Testing
- `npm run lint` *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7335fe0c83319243336e48b59476