### PR TITLE
feat: add contextual weekly planner for patient habits

### DIFF
--- a/HealthLiveApp/App.tsx
+++ b/HealthLiveApp/App.tsx
@@ -3,6 +3,7 @@ import {SafeAreaView, ScrollView, StatusBar, StyleSheet, View, Text} from 'react
 import MonitoringDashboard from './src/modules/monitoring/components/MonitoringDashboard';
 import ReminderCenter from './src/modules/reminders/components/ReminderCenter';
 import ProfileSummary from './src/modules/profile/components/ProfileSummary';
+import WeeklyPlanner from './src/modules/planner/components/WeeklyPlanner';
 
 function Section({title, children}: {title: string; children: React.ReactNode}) {
   return (
@@ -27,6 +28,9 @@ function App(): React.JSX.Element {
         </Section>
         <Section title="Recordatorios personalizados">
           <ReminderCenter />
+        </Section>
+        <Section title="Plan semanal personalizado">
+          <WeeklyPlanner />
         </Section>
         <Section title="Perfil de usuario">
           <ProfileSummary />

--- a/HealthLiveApp/src/modules/index.ts
+++ b/HealthLiveApp/src/modules/index.ts
@@ -1,3 +1,4 @@
 export * from './monitoring';
 export * from './reminders';
 export * from './profile';
+export * from './planner';

--- a/HealthLiveApp/src/modules/planner/components/WeeklyPlanner.tsx
+++ b/HealthLiveApp/src/modules/planner/components/WeeklyPlanner.tsx
@@ -1,0 +1,296 @@
+import React from 'react';
+import {
+  Alert,
+  Pressable,
+  Share,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import useUserHabits from '../hooks/useUserHabits';
+import useWeeklyPlan from '../hooks/useWeeklyPlan';
+import {
+  ActivityCategory,
+  CompletedMap,
+  PlanActivity,
+} from '../domain/types';
+import {categoryLabels} from '../domain/weeklyPlan';
+import {composeShareMessage} from '../utils/shareSummary';
+
+const categoryColors: Record<ActivityCategory, string> = {
+  meal: '#f97316',
+  exercise: '#22c55e',
+  rest: '#38bdf8',
+  relaxation: '#a855f7',
+};
+
+const WeeklyPlanner: React.FC = () => {
+  const habits = useUserHabits();
+  const plan = useWeeklyPlan(habits);
+  const [completed, setCompleted] = React.useState<CompletedMap>({});
+
+  const totalActivities = React.useMemo(
+    () => plan.days.reduce((acc, day) => acc + day.activities.length, 0),
+    [plan.days],
+  );
+
+  const completedCount = React.useMemo(
+    () =>
+      plan.days.reduce(
+        (acc, day) =>
+          acc + day.activities.filter(activity => completed[activity.id]).length,
+        0,
+      ),
+    [plan.days, completed],
+  );
+
+  const toggleActivity = React.useCallback((activityId: string) => {
+    setCompleted(prev => ({
+      ...prev,
+      [activityId]: !prev[activityId],
+    }));
+  }, []);
+
+  const handleShare = React.useCallback(async () => {
+    try {
+      const message = composeShareMessage(plan, completed, habits);
+      await Share.share({
+        title: 'Plan semanal cardiovascular',
+        message,
+      });
+    } catch (error) {
+      Alert.alert('No fue posible compartir', 'Inténtalo nuevamente más tarde.');
+    }
+  }, [plan, completed, habits]);
+
+  const renderActivity = (activity: PlanActivity) => {
+    const isCompleted = Boolean(completed[activity.id]);
+    return (
+      <Pressable
+        key={activity.id}
+        onPress={() => toggleActivity(activity.id)}
+        style={({pressed}) => [
+          styles.activityCard,
+          {borderColor: categoryColors[activity.category]},
+          isCompleted && styles.activityCardCompleted,
+          pressed && styles.activityCardPressed,
+        ]}>
+        <View style={styles.activityHeader}>
+          <View
+            style={[styles.categoryBadge, {backgroundColor: categoryColors[activity.category]}]}>
+            <Text style={styles.categoryBadgeText}>
+              {categoryLabels[activity.category]}
+            </Text>
+          </View>
+          <Text style={styles.activityTime}>{activity.time}</Text>
+        </View>
+        <Text style={styles.activityTitle}>{activity.title}</Text>
+        <Text style={styles.activityDescription}>{activity.description}</Text>
+        <Text style={styles.activityContext}>{activity.context}</Text>
+        {isCompleted ? (
+          <Text style={styles.completedLabel}>Marcada como completada ✓</Text>
+        ) : null}
+      </Pressable>
+    );
+  };
+
+  return (
+    <View>
+      <View style={styles.header}>
+        <Text style={styles.title}>Plan semanal cardioprotector</Text>
+        <Text style={styles.subtitle}>
+          Personalizado según tus hábitos {habits.exerciseBestTime === 'mañana'
+            ? 'matutinos'
+            : 'vespertinos'} y el patrón {habits.dietaryPattern.toLowerCase()}.
+        </Text>
+      </View>
+
+      <View style={styles.progressContainer}>
+        <Text style={styles.progressLabel}>Progreso semanal</Text>
+        <Text style={styles.progressValue}>
+          {completedCount} / {totalActivities} actividades completadas
+        </Text>
+      </View>
+
+      <View style={styles.recommendationsContainer}>
+        <Text style={styles.sectionLabel}>Recomendaciones contextualizadas</Text>
+        {plan.recommendations.map(recommendation => (
+          <Text key={recommendation} style={styles.recommendationItem}>
+            • {recommendation}
+          </Text>
+        ))}
+      </View>
+
+      {plan.days.map(day => (
+        <View key={day.day} style={styles.dayCard}>
+          <View style={styles.dayHeader}>
+            <Text style={styles.dayTitle}>{day.day}</Text>
+            <Text style={styles.dayFocus}>{day.focus}</Text>
+          </View>
+          <Text style={styles.dayRecommendation}>{day.recommendation}</Text>
+          {day.activities.map(renderActivity)}
+        </View>
+      ))}
+
+      <Pressable
+        onPress={handleShare}
+        style={({pressed}) => [styles.shareButton, pressed && styles.shareButtonPressed]}>
+        <Text style={styles.shareButtonText}>Compartir resumen con mi cardiólogo</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#334155',
+  },
+  progressContainer: {
+    backgroundColor: '#e0f2fe',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 16,
+  },
+  progressLabel: {
+    fontSize: 12,
+    color: '#0369a1',
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  progressValue: {
+    fontSize: 16,
+    color: '#0f172a',
+    fontWeight: '600',
+  },
+  recommendationsContainer: {
+    backgroundColor: '#f8fafc',
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 16,
+  },
+  sectionLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 8,
+  },
+  recommendationItem: {
+    fontSize: 13,
+    color: '#1e293b',
+    marginBottom: 4,
+  },
+  dayCard: {
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    backgroundColor: '#fff',
+  },
+  dayHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  dayTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  dayFocus: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#0284c7',
+  },
+  dayRecommendation: {
+    fontSize: 13,
+    color: '#334155',
+    marginBottom: 12,
+  },
+  activityCard: {
+    borderWidth: 1.5,
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+    backgroundColor: '#f8fafc',
+  },
+  activityCardCompleted: {
+    backgroundColor: '#dcfce7',
+    borderColor: '#22c55e',
+  },
+  activityCardPressed: {
+    opacity: 0.85,
+  },
+  activityHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+    alignItems: 'center',
+  },
+  categoryBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+  },
+  categoryBadgeText: {
+    fontSize: 11,
+    color: '#fff',
+    fontWeight: '700',
+  },
+  activityTime: {
+    fontSize: 12,
+    color: '#0369a1',
+    fontWeight: '600',
+  },
+  activityTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 4,
+  },
+  activityDescription: {
+    fontSize: 13,
+    color: '#1e293b',
+    marginBottom: 4,
+  },
+  activityContext: {
+    fontSize: 12,
+    color: '#475569',
+  },
+  completedLabel: {
+    marginTop: 8,
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#15803d',
+  },
+  shareButton: {
+    marginTop: 12,
+    backgroundColor: '#0284c7',
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  shareButtonPressed: {
+    backgroundColor: '#0369a1',
+  },
+  shareButtonText: {
+    color: '#f8fafc',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});
+
+export default WeeklyPlanner;

--- a/HealthLiveApp/src/modules/planner/domain/types.ts
+++ b/HealthLiveApp/src/modules/planner/domain/types.ts
@@ -1,0 +1,50 @@
+export type ActivityCategory = 'meal' | 'exercise' | 'rest' | 'relaxation';
+
+export interface PlanActivity {
+  id: string;
+  category: ActivityCategory;
+  title: string;
+  description: string;
+  time: string;
+  context: string;
+}
+
+export interface DailyPlan {
+  day: string;
+  focus: string;
+  recommendation: string;
+  activities: PlanActivity[];
+}
+
+export interface WeeklyPlan {
+  days: DailyPlan[];
+  recommendations: string[];
+  cardiologistSummary: string;
+}
+
+export type StressLevel = 'bajo' | 'moderado' | 'alto';
+export type ExerciseIntensity = 'suave' | 'moderado' | 'alto';
+export type ExerciseBestTime = 'mañana' | 'tarde';
+
+export interface UserHabits {
+  patientName: string;
+  dietaryPattern: string;
+  dietaryRestrictions: string[];
+  breakfastTime: string;
+  lunchTime: string;
+  dinnerTime: string;
+  hydrationGoalLiters: number;
+  preferredExercise: string;
+  exerciseIntensity: ExerciseIntensity;
+  exerciseBestTime: ExerciseBestTime;
+  restRoutine: string;
+  relaxationPreference: string;
+  stressLevel: StressLevel;
+  sleepGoalHours: number;
+  supportNotes: string;
+  medicationSchedule: string[];
+}
+
+export interface CompletedMap {
+  [activityId: string]: boolean;
+}

--- a/HealthLiveApp/src/modules/planner/domain/weeklyPlan.ts
+++ b/HealthLiveApp/src/modules/planner/domain/weeklyPlan.ts
@@ -1,0 +1,261 @@
+import {DailyPlan, PlanActivity, UserHabits, WeeklyPlan} from './types';
+
+const daysOfWeek = [
+  'Lunes',
+  'Martes',
+  'Miércoles',
+  'Jueves',
+  'Viernes',
+  'Sábado',
+  'Domingo',
+];
+
+interface ActivityBlueprint {
+  focus: string;
+  meal: {title: string; description: string};
+  exercise: {title: string; description: string};
+  rest: {title: string; description: string};
+  relaxation: {title: string; description: string};
+}
+
+const weeklyBlueprints: ActivityBlueprint[] = [
+  {
+    focus: 'Arranque equilibrado',
+    meal: {
+      title: 'Desayuno rico en potasio',
+      description:
+        'Avena con frutos rojos, semillas y nueces para mantener energía estable.',
+    },
+    exercise: {
+      title: 'Caminata consciente',
+      description: '20 minutos controlando respiración y postura.',
+    },
+    rest: {
+      title: 'Pausa de respiraciones',
+      description: 'Micro pausa de 10 minutos para relajar hombros y cuello.',
+    },
+    relaxation: {
+      title: 'Escaneo corporal guiado',
+      description: 'Revisión progresiva de tensiones antes de dormir.',
+    },
+  },
+  {
+    focus: 'Fortalecimiento progresivo',
+    meal: {
+      title: 'Almuerzo hiposódico',
+      description:
+        'Ensalada con garbanzos, espinacas y aliño de limón para apoyar presión arterial.',
+    },
+    exercise: {
+      title: 'Intervalos suaves',
+      description: 'Alterna 3 minutos de caminata rápida con 2 minutos suaves.',
+    },
+    rest: {
+      title: 'Siesta breve supervisada',
+      description: '15 minutos en posición semi-reclinada con piernas elevadas.',
+    },
+    relaxation: {
+      title: 'Respiración 4-7-8',
+      description: 'Secuencia de respiraciones profundas para reducir estrés.',
+    },
+  },
+  {
+    focus: 'Movilidad y flexibilidad',
+    meal: {
+      title: 'Media mañana antioxidante',
+      description: 'Yogur con arándanos y semillas de chía para cuidar vasos sanguíneos.',
+    },
+    exercise: {
+      title: 'Rutina de movilidad articular',
+      description: 'Serie de movimientos suaves para hombros, cadera y columna.',
+    },
+    rest: {
+      title: 'Desconexión digital',
+      description: 'Bloquea 30 minutos sin pantallas antes de acostarte.',
+    },
+    relaxation: {
+      title: 'Baño de pies tibio',
+      description: 'Agrega sales de magnesio para favorecer retorno venoso.',
+    },
+  },
+  {
+    focus: 'Resistencia moderada',
+    meal: {
+      title: 'Cena ligera cardioprotectora',
+      description: 'Pescado al horno con verduras de hoja verde y aceite de oliva.',
+    },
+    exercise: {
+      title: 'Sesión de elíptica o bici estática',
+      description: '25 minutos manteniendo frecuencia cardiaca en zona segura.',
+    },
+    rest: {
+      title: 'Rutina de estiramientos nocturnos',
+      description: 'Enfoque en cadena posterior para evitar rigidez.',
+    },
+    relaxation: {
+      title: 'Diario de gratitud',
+      description: 'Anota tres logros o gratitudes antes de dormir.',
+    },
+  },
+  {
+    focus: 'Gestión del estrés',
+    meal: {
+      title: 'Snack rico en magnesio',
+      description: 'Puñado de almendras y kiwi para apoyar relajación muscular.',
+    },
+    exercise: {
+      title: 'Sesión de fuerza funcional',
+      description: 'Circuito con bandas elásticas enfocando tren superior e inferior.',
+    },
+    rest: {
+      title: 'Respiración diafragmática guiada',
+      description: '5 minutos recostada con piernas elevadas.',
+    },
+    relaxation: {
+      title: 'Meditación guiada',
+      description: 'Usa tu app favorita durante 12 minutos.',
+    },
+  },
+  {
+    focus: 'Conexión social activa',
+    meal: {
+      title: 'Brunch equilibrado',
+      description: 'Tostadas integrales con aguacate, tomate y proteínas magras.',
+    },
+    exercise: {
+      title: 'Salida recreativa',
+      description: 'Paseo en naturaleza o parque acompañada.',
+    },
+    rest: {
+      title: 'Siesta opcional',
+      description: '20 minutos de descanso tras la comida principal.',
+    },
+    relaxation: {
+      title: 'Actividad placentera',
+      description: 'Lectura ligera o música relajante al final del día.',
+    },
+  },
+  {
+    focus: 'Preparación para la semana',
+    meal: {
+      title: 'Planificación de batch cooking',
+      description: 'Organiza menús bajos en sodio para la semana siguiente.',
+    },
+    exercise: {
+      title: 'Estiramiento global activo',
+      description: 'Secuencia de 20 minutos centrada en respiración y postura.',
+    },
+    rest: {
+      title: 'Higiene del sueño',
+      description: 'Rutina relajante con luces cálidas y lectura breve.',
+    },
+    relaxation: {
+      title: 'Visualización guiada',
+      description: 'Proyecta metas de la semana mientras respiras profundo.',
+    },
+  },
+];
+
+const categoryLabels = {
+  meal: 'Nutrición',
+  exercise: 'Ejercicio',
+  rest: 'Descanso',
+  relaxation: 'Relajación',
+} as const;
+
+const mapToActivities = (
+  blueprint: ActivityBlueprint,
+  day: string,
+  index: number,
+  habits: UserHabits,
+): PlanActivity[] => {
+  const exerciseTime = habits.exerciseBestTime === 'mañana' ? '07:00' : '18:30';
+  const restTime = habits.exerciseBestTime === 'mañana' ? '13:30' : '15:30';
+  const relaxationTime = '21:30';
+
+  return [
+    {
+      id: `${day.toLowerCase()}-meal`,
+      category: 'meal',
+      title: `${blueprint.meal.title}`,
+      time: index % 2 === 0 ? habits.breakfastTime : habits.lunchTime,
+      description: `${blueprint.meal.description} Adaptado al patrón ${habits.dietaryPattern} y tus restricciones: ${habits.dietaryRestrictions.join(', ')}.`,
+      context: 'Alimentación cardio-protectora',
+    },
+    {
+      id: `${day.toLowerCase()}-exercise`,
+      category: 'exercise',
+      title: `${blueprint.exercise.title} (${habits.preferredExercise})`,
+      time: exerciseTime,
+      description: `${blueprint.exercise.description} Ajusta intensidad a un nivel ${habits.exerciseIntensity} y monitorea la respiración.`,
+      context: 'Condicionamiento físico seguro',
+    },
+    {
+      id: `${day.toLowerCase()}-rest`,
+      category: 'rest',
+      title: blueprint.rest.title,
+      time: restTime,
+      description: `${blueprint.rest.description} Incorpora tu rutina habitual: ${habits.restRoutine}.`,
+      context: 'Recuperación y ritmo circadiano',
+    },
+    {
+      id: `${day.toLowerCase()}-relax`,
+      category: 'relaxation',
+      title: blueprint.relaxation.title,
+      time: relaxationTime,
+      description: `${blueprint.relaxation.description} Integra tu preferencia: ${habits.relaxationPreference}.`,
+      context: 'Regulación emocional',
+    },
+  ];
+};
+
+const buildDailyRecommendation = (
+  blueprint: ActivityBlueprint,
+  habits: UserHabits,
+): string => {
+  const stressMessage =
+    habits.stressLevel === 'alto'
+      ? 'Prioriza técnicas de respiración lenta y valida nivel de estrés antes de dormir.'
+      : habits.stressLevel === 'moderado'
+      ? 'Incluye recordatorios para revisar respiración y postura durante la jornada.'
+      : 'Mantén un registro breve para asegurar que el estrés siga bajo control.';
+
+  return `${blueprint.focus}: ${stressMessage} Aprovecha las ${habits.supportNotes.toLowerCase()} para reforzar adherencia.`;
+};
+
+const buildHabitRecommendations = (habits: UserHabits): string[] => [
+  `Hidratación diaria objetivo: ${habits.hydrationGoalLiters.toFixed(1)} L distribuidos en bloques de mañana y tarde.`,
+  `Programa la actividad física en la ${habits.exerciseBestTime} aprovechando tu preferencia por ${habits.preferredExercise}.`,
+  `Sostén un promedio de ${habits.sleepGoalHours} h de sueño con higiene nocturna consistente.`,
+  `Menú basado en el patrón ${habits.dietaryPattern} atendiendo a ${habits.dietaryRestrictions.join(', ')}.`,
+  `Medicación en horarios: ${habits.medicationSchedule.join(' y ')} para estabilidad hemodinámica.`,
+];
+
+const buildCardiologistSummary = (habits: UserHabits, days: DailyPlan[]): string => {
+  const totalActivities = days.reduce((acc, day) => acc + day.activities.length, 0);
+  const exerciseSessions = days.length;
+  return `Plan semanal centrado en ${habits.preferredExercise} con ${exerciseSessions} sesiones de ejercicio moderado y ${totalActivities} intervenciones totales. Se prioriza pauta ${habits.dietaryPattern} y control de estrés ${habits.stressLevel}.`;
+};
+
+export const buildWeeklyPlan = (habits: UserHabits): WeeklyPlan => {
+  const days = daysOfWeek.map((day, index) => {
+    const blueprint = weeklyBlueprints[index];
+    const activities = mapToActivities(blueprint, day, index, habits);
+    const recommendation = buildDailyRecommendation(blueprint, habits);
+
+    return {
+      day,
+      focus: blueprint.focus,
+      recommendation,
+      activities,
+    };
+  });
+
+  return {
+    days,
+    recommendations: buildHabitRecommendations(habits),
+    cardiologistSummary: buildCardiologistSummary(habits, days),
+  };
+};
+
+export {categoryLabels};

--- a/HealthLiveApp/src/modules/planner/hooks/useUserHabits.ts
+++ b/HealthLiveApp/src/modules/planner/hooks/useUserHabits.ts
@@ -1,0 +1,25 @@
+import {useMemo} from 'react';
+import {UserHabits} from '../domain/types';
+
+const defaultHabits: UserHabits = {
+  patientName: 'María Rivera',
+  dietaryPattern: 'DASH con enfoque mediterráneo',
+  dietaryRestrictions: ['bajo sodio', 'alto contenido en fibra'],
+  breakfastTime: '07:30',
+  lunchTime: '13:30',
+  dinnerTime: '20:00',
+  hydrationGoalLiters: 2.2,
+  preferredExercise: 'caminata rápida al aire libre',
+  exerciseIntensity: 'moderado',
+  exerciseBestTime: 'mañana',
+  restRoutine: 'siesta corta de 15 minutos tras el almuerzo',
+  relaxationPreference: 'respiración diafragmática con música suave',
+  stressLevel: 'moderado',
+  sleepGoalHours: 7.5,
+  supportNotes: 'sesiones de coaching cardiovascular y recordatorios del equipo médico',
+  medicationSchedule: ['08:00', '20:00'],
+};
+
+const useUserHabits = (): UserHabits => useMemo(() => defaultHabits, []);
+
+export default useUserHabits;

--- a/HealthLiveApp/src/modules/planner/hooks/useWeeklyPlan.ts
+++ b/HealthLiveApp/src/modules/planner/hooks/useWeeklyPlan.ts
@@ -1,0 +1,8 @@
+import {useMemo} from 'react';
+import {buildWeeklyPlan} from '../domain/weeklyPlan';
+import {UserHabits, WeeklyPlan} from '../domain/types';
+
+const useWeeklyPlan = (habits: UserHabits): WeeklyPlan =>
+  useMemo(() => buildWeeklyPlan(habits), [habits]);
+
+export default useWeeklyPlan;

--- a/HealthLiveApp/src/modules/planner/index.ts
+++ b/HealthLiveApp/src/modules/planner/index.ts
@@ -1,0 +1,4 @@
+export {default as WeeklyPlanner} from './components/WeeklyPlanner';
+export {default as useUserHabits} from './hooks/useUserHabits';
+export {default as useWeeklyPlan} from './hooks/useWeeklyPlan';
+export * from './domain/types';

--- a/HealthLiveApp/src/modules/planner/utils/shareSummary.ts
+++ b/HealthLiveApp/src/modules/planner/utils/shareSummary.ts
@@ -1,0 +1,46 @@
+import {CompletedMap, DailyPlan, UserHabits, WeeklyPlan} from '../domain/types';
+
+const getCompletedCount = (days: DailyPlan[], completed: CompletedMap): number =>
+  days.reduce(
+    (acc, day) =>
+      acc + day.activities.filter(activity => completed[activity.id]).length,
+    0,
+  );
+
+const getPendingByDay = (days: DailyPlan[], completed: CompletedMap): string[] =>
+  days
+    .map(day => {
+      const pending = day.activities.filter(activity => !completed[activity.id]);
+      if (pending.length === 0) {
+        return null;
+      }
+
+      const pendingTitles = pending.map(activity => activity.title).join(', ');
+      return `${day.day}: ${pendingTitles}`;
+    })
+    .filter((item): item is string => item !== null);
+
+export const composeShareMessage = (
+  plan: WeeklyPlan,
+  completed: CompletedMap,
+  habits: UserHabits,
+): string => {
+  const totalActivities = plan.days.reduce(
+    (acc, day) => acc + day.activities.length,
+    0,
+  );
+  const completedCount = getCompletedCount(plan.days, completed);
+  const pendingByDay = getPendingByDay(plan.days, completed);
+
+  const header = `Resumen semanal de ${habits.patientName}`;
+  const progressLine = `Progreso: ${completedCount}/${totalActivities} actividades completadas.`;
+  const recommendations = plan.recommendations
+    .map(recommendation => `• ${recommendation}`)
+    .join('\n');
+  const pendingSection =
+    pendingByDay.length > 0
+      ? `Pendientes a vigilar:\n${pendingByDay.join('\n')}`
+      : 'Todas las actividades fueron completadas.';
+
+  return `${header}\n${plan.cardiologistSummary}\n${progressLine}\n\nRecomendaciones clave:\n${recommendations}\n\n${pendingSection}`;
+};


### PR DESCRIPTION
## Summary
- add planner module with weekly plan data structures and contextual recommendations based on stored habits
- create interactive daily views to mark activities as completed and export a cardiologist summary
- surface the personalized weekly plan in the main app alongside existing modules

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js and project dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7581a4608331ab2d02079b3f30a7